### PR TITLE
Fix for: name 'file_names' is not defined in SNR notebook

### DIFF
--- a/notebooks/dataset_analysis/CheckDatasetSNR.ipynb
+++ b/notebooks/dataset_analysis/CheckDatasetSNR.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook computes the average SNR a given Voice Dataset. If the SNR is too low, that might reduce the performance or prevent model to learn.\n",
+    "This notebook computes the average SNR a given Voice Dataset. If the SNR is too low, that might reduce the performance or prevent model to learn. SNR paper can be seen here: https://www.cs.cmu.edu/~robust/Papers/KimSternIS08.pdf\n",
     "\n",
     "To use this notebook, you need:\n",
     "- WADA SNR estimation: http://www.cs.cmu.edu/~robust/archive/algorithms/WADA_SNR_IS_2008/\n",
@@ -136,7 +136,7 @@
     "snrs = [tup[0] for tup in file_snrs]\n",
     "\n",
     "error_idxs = np.where(np.isnan(snrs) == True)[0]\n",
-    "error_files = [file_names[idx] for idx in error_idxs]\n",
+    "error_files = [wav_files[idx] for idx in error_idxs]\n",
     "\n",
     "file_snrs = [i for j, i in enumerate(file_snrs) if j not in error_idxs]\n",
     "file_names = [tup[1] for tup in file_snrs]\n",


### PR DESCRIPTION
Running notebook brought following error: ```NameError: name 'file_names' is not defined.``` while executing step 7.

As "file_names" hasn't been defined before usage i've to changed it to wav_files.
Additionally i've added link to SNR paper.

