### PR TITLE
Fix the "Run your own TTS and Vocoder models" snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ tts --text "Text for TTS" \
 Run your own TTS and Vocoder models
 ```bash
 tts --text "Text for TTS" \
-    --model_path path/to/config.json \
-    --config_path path/to/model.pth.tar \
+    --config_path path/to/config.json \
+    --model_path path/to/model.pth.tar \
     --out_path folder/to/save/output.wav \
     --vocoder_path path/to/vocoder.pth.tar \
     --vocoder_config_path path/to/vocoder_config.json


### PR DESCRIPTION
It was trying to load the model as the config file and failed.

To run the Russian model I also had to omit the vocoder options and edit the config.json to fix an absolute path that was left over from the developer's machine.