### PR TITLE
`mixed_precision` set to false

### DIFF
--- a/recipes/ljspeech/tacotron2-DDC/tacotron2-DDC.json
+++ b/recipes/ljspeech/tacotron2-DDC/tacotron2-DDC.json
@@ -41,7 +41,7 @@
     "run_description": "tacotron2 with double decoder consistency.",
     "batch_size": 64,
     "eval_batch_size": 16,
-    "mixed_precision": true,
+    "mixed_precision": false,
     "loss_masking": true,
     "decoder_loss_alpha": 0.25,
     "postnet_loss_alpha": 0.25,


### PR DESCRIPTION
Change default value of `"mixed_precision" : false` as when it is set true it leads to  `raise RuntimeError(f" [!] NaN loss with {key}.")
RuntimeError:  [!] NaN loss with decoder_loss.`