### PR TITLE
Fix test inferences not happening during training

### DIFF
--- a/TTS/trainer.py
+++ b/TTS/trainer.py
@@ -764,7 +764,7 @@ class Trainer:
         """Run test and log the results. Test run must be defined by the model.
         Model must return figures and audios to be logged by the Tensorboard."""
         if hasattr(self.model, "test_run"):
-            if hasattr(self.eval_loader.load_test_samples):
+            if hasattr(self.eval_loader, "load_test_samples"):
                 samples = self.eval_loader.load_test_samples(1)
                 figures, audios = self.model.test_run(samples)
             else:

--- a/TTS/trainer.py
+++ b/TTS/trainer.py
@@ -790,7 +790,7 @@ class Trainer:
             self.train_epoch()
             if self.config.run_eval:
                 self.eval_epoch()
-            if epoch >= self.config.test_delay_epochs and self.args.rank < 0:
+            if epoch >= self.config.test_delay_epochs and self.args.rank == 0:
                 self.test_run()
             self.c_logger.print_epoch_end(
                 epoch, self.keep_avg_eval.avg_values if self.config.run_eval else self.keep_avg_train.avg_values


### PR DESCRIPTION
I noticed test inferences weren't happening during training. I think this line is the issue. [Logic copied from here.](https://github.com/coqui-ai/TTS/blob/d245b5d48f01cdaf45479b7f924b8a74b6c58b97/TTS/bin/train_tacotron.py#L524)
