### PR TITLE
Bump gruut version to 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ coqpit
 mecab-python3==1.0.3
 unidic-lite==1.0.8
 # gruut+supported langs
-gruut[cs,de,es,fr,it,nl,pt,ru,sv]~=1.2.0
+gruut[ar,cs,de,es,fa,fr,it,nl,pt,ru,sv,sw]~=1.3.0


### PR DESCRIPTION
* Use new version of gruut (1.3.1) with rebuilt eSpeak lexicons and g2p models.
* Add newly supported gruut languages: Arabic (ar), Farsi (fa), and Swahili (sw)
    * Needs [a fork of num2words](https://github.com/rhasspy/num2words/releases/tag/v0.6.0) for number expansion (maybe this library should just be included inside gruut?)

## Notes

There will be style/test failures, but it's unclear if they should be fixed here or directly on `dev`. Specifically:

Running `make style` reformatted `TTS/bin/distribute.py` (not modified here).

Running `make test` had failures for some models with `use_phonemes: true` but `characters.phonemes: null` in their configs. It looks like `make_symbols` does not return the default set of phonemes in this case, which causes failures during synthesis.