### PR TITLE
Fix path issues for resume training with restore_path

### DIFF
--- a/TTS/trainer.py
+++ b/TTS/trainer.py
@@ -818,9 +818,9 @@ class Trainer:
 
     def _fit(self) -> None:
         """🏃 train -> evaluate -> test for the number of epochs."""
-        if self.restore_step != 0 or self.args.best_path:
-            print(" > Restoring best loss from " f"{os.path.basename(self.args.best_path)} ...")
-            self.best_loss = load_fsspec(self.args.best_path, map_location="cpu")["model_loss"]
+        if self.restore_step != 0 or self.args.restore_path:
+            print(" > Restoring best loss from " f"{os.path.basename(self.args.restore_path)} ...")
+            self.best_loss = load_fsspec(self.args.restore_path, map_location="cpu")["model_losses"]
             print(f" > Starting with loaded last best loss {self.best_loss}.")
 
         self.total_steps_done = self.restore_step


### PR DESCRIPTION
Resume training was failing as no correct path was provided. So instead of `self.args.best_path` this `self.args.restore_path` should be provided.