### PR TITLE
When restoring from checkpoint, make model_loss optional

### DIFF
--- a/TTS/trainer.py
+++ b/TTS/trainer.py
@@ -820,8 +820,12 @@ class Trainer:
         """🏃 train -> evaluate -> test for the number of epochs."""
         if self.restore_step != 0 or self.args.best_path:
             print(" > Restoring best loss from " f"{os.path.basename(self.args.best_path)} ...")
-            self.best_loss = load_fsspec(self.args.restore_path, map_location="cpu")["model_loss"]
-            print(f" > Starting with loaded last best loss {self.best_loss}.")
+            fsspec = load_fsspec(self.args.restore_path, map_location="cpu")
+            if "model_loss" in fsspec:
+                self.best_loss = fsspec["model_loss"]
+                print(f" > Starting with loaded last best loss {self.best_loss}.")
+            else:
+                print(f" > Model has no best loss.")
 
         self.total_steps_done = self.restore_step
 

--- a/TTS/trainer.py
+++ b/TTS/trainer.py
@@ -820,9 +820,9 @@ class Trainer:
         """🏃 train -> evaluate -> test for the number of epochs."""
         if self.restore_step != 0 or self.args.best_path:
             print(" > Restoring best loss from " f"{os.path.basename(self.args.best_path)} ...")
-            fsspec = load_fsspec(self.args.restore_path, map_location="cpu")
-            if "model_loss" in fsspec:
-                self.best_loss = fsspec["model_loss"]
+            checkpoint = load_fsspec(self.args.restore_path, map_location="cpu")
+            if "model_loss" in checkpoint:
+                self.best_loss = checkpoint["model_loss"]
                 print(f" > Starting with loaded last best loss {self.best_loss}.")
             else:
                 print(f" > Model has no best loss.")


### PR DESCRIPTION
I tried restoring from latest VITS ljspeech checkpoint and got this error:

```
 > Restoring best loss from  ...
 ! Run is removed from /home/fijipants/repo/coqui-0.2/runs/-August-13-2021_08+59PM-c3082267
Traceback (most recent call last):
  File "/home/fijipants/repo/coqui-0.2/TTS/trainer.py", line 848, in fit
    self._fit()
  File "/home/fijipants/repo/coqui-0.2/TTS/trainer.py", line 823, in _fit
    self.best_loss = load_fsspec(self.args.restore_path, map_location="cpu")["model_loss"]
KeyError: 'model_loss'
```

I think this should fix that.