### PR TITLE
Update gruut to version 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ coqpit
 mecab-python3==1.0.3
 unidic-lite==1.0.8
 # gruut+supported langs
-gruut[cs,de,es,fr,it,nl,pt,ru,sv]~=1.2.0
+gruut[cs,de,es,fr,it,nl,pt,ru,sv]~=2.0.0
 fsspec>=2021.04.0
 pyworld

--- a/tests/aux_tests/test_text_processing.py
+++ b/tests/aux_tests/test_text_processing.py
@@ -9,12 +9,12 @@ LANG = "en-us"
 
 EXAMPLE_TEXT = "Recent research at Harvard has shown meditating for as little as 8 weeks can actually increase, the grey matter in the parts of the brain responsible for emotional regulation and learning!"
 
-EXPECTED_PHONEMES = "ɹ|iː|s|ə|n|t| ɹ|ᵻ|s|ɜː|tʃ| æ|t| h|ɑːɹ|v|ɚ|d| h|æ|z| ʃ|oʊ|n| m|ɛ|d|ᵻ|t|eɪ|ɾ|ɪ|ŋ| f|ɔːɹ| æ|z| l|ɪ|ɾ|əl| æ|z| eɪ|t| w|iː|k|s| k|æ|n| æ|k|tʃ|uː|əl|i| ɪ|ŋ|k|ɹ|iː|s| ,| ð|ə| ɡ|ɹ|eɪ| m|æ|ɾ|ɚ| ɪ|n| ð|ə| p|ɑːɹ|t|s| ʌ|v| ð|ə| b|ɹ|eɪ|n| ɹ|ᵻ|s|p|ɑː|n|s|ᵻ|b|əl| f|ɔːɹ| ɪ|m|oʊ|ʃ|ə|n|əl| ɹ|ɛ|ɡ|j|ʊ|l|eɪ|ʃ|ə|n| æ|n|d| l|ɜː|n|ɪ|ŋ| !"
+EXPECTED_PHONEMES = "ɹ|i|ː|s|ə|n|t| ɹ|ᵻ|s|ɜ|ː|t|ʃ| æ|ɾ| h|ɑ|ː|ɹ|v|ɚ|d| h|ɐ|z| ʃ|o|ʊ|n| m|ɛ|d|ᵻ|t|e|ɪ|ɾ|ɪ|ŋ| f|ɔ|ː|ɹ| æ|z| l|ɪ|ɾ|ə|l| æ|z| e|ɪ|t| w|i|ː|k|s| k|æ|ŋ| æ|k|t|ʃ|u|ː|ə|l|i| ɪ|ŋ|k|ɹ|i|ː|s|,| ð|ə| ɡ|ɹ|e|ɪ| m|æ|ɾ|ɚ| ɪ|n| ð|ə| p|ɑ|ː|ɹ|t|s| ʌ|v| ð|ə| b|ɹ|e|ɪ|n| ɹ|ᵻ|s|p|ɑ|ː|n|s|ᵻ|b|ə|l| f|ɔ|ː|ɹ| ɪ|m|o|ʊ|ʃ|ə|n|ə|l| ɹ|ɛ|ɡ|j|ʊ|l|e|ɪ|ʃ|ə|n| æ|n|d| l|ɜ|ː|n|ɪ|ŋ|!"
 
 # -----------------------------------------------------------------------------
 
 
-class TextProcessingTextCase(unittest.TestCase):
+class TextProcessingTestCase(unittest.TestCase):
     """Tests for text to phoneme conversion"""
 
     def test_phoneme_to_sequence(self):
@@ -40,7 +40,7 @@ class TextProcessingTextCase(unittest.TestCase):
         sequence = phoneme_to_sequence(text, text_cleaner, LANG, add_blank=add_blank, use_espeak_phonemes=True)
         text_hat = sequence_to_phoneme(sequence)
         text_hat_with_params = sequence_to_phoneme(sequence)
-        gt = "biː ɐ vɔɪs , nɑːt ɐn ! ɛkoʊ ?"
+        gt = "biː ɐ vɔɪs, nɑːt ɐn! ɛkoʊ?"
         print(text_hat)
         print(len(sequence))
         self.assertEqual(text_hat, text_hat_with_params)
@@ -51,7 +51,7 @@ class TextProcessingTextCase(unittest.TestCase):
         sequence = phoneme_to_sequence(text, text_cleaner, LANG, add_blank=add_blank, use_espeak_phonemes=True)
         text_hat = sequence_to_phoneme(sequence)
         text_hat_with_params = sequence_to_phoneme(sequence)
-        gt = "biː ɐ vɔɪs , nɑːt ɐn ! ɛkoʊ"
+        gt = "biː ɐ vɔɪs, nɑːt ɐn! ɛkoʊ"
         print(text_hat)
         print(len(sequence))
         self.assertEqual(text_hat, text_hat_with_params)
@@ -62,7 +62,7 @@ class TextProcessingTextCase(unittest.TestCase):
         sequence = phoneme_to_sequence(text, text_cleaner, LANG, add_blank=add_blank, use_espeak_phonemes=True)
         text_hat = sequence_to_phoneme(sequence)
         text_hat_with_params = sequence_to_phoneme(sequence)
-        gt = "biː ɐ vɔɪs , nɑːt ɐn ɛkoʊ !"
+        gt = "biː ɐ vɔɪs, nɑːt ɐn ɛkoʊ!"
         print(text_hat)
         print(len(sequence))
         self.assertEqual(text_hat, text_hat_with_params)
@@ -73,7 +73,7 @@ class TextProcessingTextCase(unittest.TestCase):
         sequence = phoneme_to_sequence(text, text_cleaner, LANG, add_blank=add_blank, use_espeak_phonemes=True)
         text_hat = sequence_to_phoneme(sequence)
         text_hat_with_params = sequence_to_phoneme(sequence)
-        gt = "biː ɐ vɔɪs , nɑːt ɐn ! ɛkoʊ ."
+        gt = "biː ɐ vɔɪs, nɑːt ɐn! ɛkoʊ."
         print(text_hat)
         print(len(sequence))
         self.assertEqual(text_hat, text_hat_with_params)
@@ -86,7 +86,7 @@ class TextProcessingTextCase(unittest.TestCase):
         )
         text_hat = sequence_to_phoneme(sequence)
         text_hat_with_params = sequence_to_phoneme(sequence)
-        gt = "^biː ɐ vɔɪs , nɑːt ɐn ! ɛkoʊ .~"
+        gt = "^biː ɐ vɔɪs, nɑːt ɐn! ɛkoʊ.~"
         print(text_hat)
         print(len(sequence))
         self.assertEqual(text_hat, text_hat_with_params)


### PR DESCRIPTION
Minimal modifications for the update to gruut 2.0.

* eSpeak phoneme databases have been re-built with the changes discussed [here](https://github.com/coqui-ai/TTS/issues/680)
* Whitespace is now preserved as per the discussion [here](https://github.com/coqui-ai/TTS/issues/771)

---

For the future: gruut's text processing has been greatly expanded in 2.0, and the current text cleaners in :frog: TTS interfere. For example, the sentence:

```
It is 4pm on 1/2/2013.
```

gets expanded via `phoneme_cleaners` to:

```
It is fourpm on one/two/twenty thirteen.
```

One way to solve this problem would be to use gruut itself as a text cleaner:

```python
import gruut

def gruut_cleaner(text: str, lang: str = "en-us"):
    return " ".join(
        s.text_with_ws for s in gruut.sentences(text, lang=lang, phonemes=False, pos=False)
    )
```

which gets you:

```python
>>> gruut_cleaner("It is 4pm on 1/2/2013.")
'It is four P M  on January second, twenty thirteen.'
```