### PR TITLE
feat(tokenizer): add digraph support for TTSTokenizer

### DIFF
--- a/TTS/tts/utils/text/characters.py
+++ b/TTS/tts/utils/text/characters.py
@@ -1,3 +1,6 @@
+from typing import List, Union
+
+
 def parse_symbols():
     return {
         "pad": _pad,
@@ -81,10 +84,10 @@ class BaseCharacters:
         If you need a custom order, you need to define inherit from this class and override the ```_create_vocab``` method.
 
         Args:
-            characters (str):
+            characters (str|list):
                 Main set of characters to be used in the vocabulary.
 
-            punctuations (str):
+            punctuations (str|list):
                 Characters to be treated as punctuation.
 
             pad (str):
@@ -108,8 +111,8 @@ class BaseCharacters:
 
     def __init__(
         self,
-        characters: str,
-        punctuations: str,
+        characters: Union[str, List[str]],
+        punctuations: Union[str, List[str]],
         pad: str,
         eos: str,
         bos: str,
@@ -194,7 +197,9 @@ class BaseCharacters:
         if self.is_unique:
             _vocab = list(set(_vocab))
         if self.is_sorted:
-            _vocab = sorted(_vocab)
+            _vocab = sorted(
+                _vocab, key=len, reverse=True
+            )  # Python's sorting is very English-centric, reverse-length sorting helps with digraphs and is more language agnostic
         _vocab = list(_vocab)
         _vocab = [self._blank] + _vocab if self._blank is not None and len(self._blank) > 0 else _vocab
         _vocab = [self._bos] + _vocab if self._bos is not None and len(self._bos) > 0 else _vocab
@@ -209,7 +214,7 @@ class BaseCharacters:
             ), f" [!] There are duplicate characters in the character set. {set([x for x in self.vocab if self.vocab.count(x) > 1])}"
 
     def char_to_id(self, char: str) -> int:
-            return self._char_to_id[char]
+        return self._char_to_id[char]
 
     def id_to_char(self, idx: int) -> str:
         return self._id_to_char[idx]
@@ -298,8 +303,8 @@ class IPAPhonemes(BaseCharacters):
             )
         else:
             return IPAPhonemes(
-            **config.characters if config.characters is not None else {},
-        )
+                **config.characters if config.characters is not None else {},
+            )
 
 
 class Graphemes(BaseCharacters):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ inflect
 jieba
 librosa==0.8.0
 matplotlib
+nltk
 numpy==1.19.5
 pandas
 pypinyin

--- a/tests/text_tests/test_tokenizer.py
+++ b/tests/text_tests/test_tokenizer.py
@@ -12,7 +12,10 @@ from TTS.tts.utils.text.tokenizer import TTSTokenizer
 class TestTTSTokenizer(unittest.TestCase):
     def setUp(self):
         self.tokenizer = TTSTokenizer(use_phonemes=False, characters=Graphemes())
-
+        self.digraph_tokenizer = TTSTokenizer(
+            use_phonemes=False,
+            characters=Graphemes(characters=["d", "dd"]),
+        )
         self.ph = ESpeak("tr")
         self.tokenizer_ph = TTSTokenizer(use_phonemes=True, characters=IPAPhonemes(), phonemizer=self.ph)
 
@@ -22,6 +25,13 @@ class TestTTSTokenizer(unittest.TestCase):
         test_hat = self.tokenizer.decode(ids)
         self.assertEqual(text, test_hat)
         self.assertEqual(len(ids), len(text))
+
+    def test_digraph_text_to_ids(self):
+        text = "dd"
+        ids = self.digraph_tokenizer.encode(text)
+        test_hat = self.digraph_tokenizer.decode(ids)
+        self.assertEqual(text, test_hat)
+        self.assertEqual(len(ids), 1)
 
     def test_text_to_ids_phonemes(self):
         # TODO: note sure how to extend to cover all the languages and phonemizer.


### PR DESCRIPTION
Here is a possible integration of a digraph-aware tokenizer. Note that there was a failed unittest when I pulled this. I didn't try to fix that test as it wasn't clear what the issue was. See: `FAIL: test_text_to_ids_phonemes_with_eos_bos_and_blank (test_tokenizer.TestTTSTokenizer)`.

A couple things to note:
- This replaces Python's default sorting with reverse length sorting. I add a comment for why this might be a good idea.
- TTSTokenizer.encode was being passed both strings and lists by the unittests - I updated the type definition accordingly
- This introduces a dependency on nltk. I think this is fairly lightweight, but if you're concerned, it isn't a difficult class to implement, see https://www.nltk.org/_modules/nltk/tokenize/regexp.html 

Note that I believe this would fix https://github.com/coqui-ai/TTS/issues/1072 but it would not fix https://github.com/coqui-ai/TTS/issues/1075