### PR TITLE
Bug fixes: Input size check and server config file path fix. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ internal/*
 *_phoneme.npy
 wandb
 depot/*
+bin
+pyvenv.cfg

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -151,8 +151,8 @@ def index():
 @app.route("/details")
 def details():
     model_config = load_config(config_path)
-    if args.vocoder_config is not None and os.path.isfile(args.vocoder_config):
-        vocoder_config = load_config(args.vocoder_config)
+    if vocoder_config_path is not None and os.path.isfile(vocoder_config_path):
+        vocoder_config = load_config(vocoder_config_path)
     else:
         vocoder_config = None
 

--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -150,7 +150,7 @@ def index():
 
 @app.route("/details")
 def details():
-    model_config = load_config(args.tts_config)
+    model_config = load_config(config_path)
     if args.vocoder_config is not None and os.path.isfile(args.vocoder_config):
         vocoder_config = load_config(args.vocoder_config)
     else:

--- a/TTS/tts/layers/vits/transforms.py
+++ b/TTS/tts/layers/vits/transforms.py
@@ -109,7 +109,7 @@ def rational_quadratic_spline(
     min_bin_height=DEFAULT_MIN_BIN_HEIGHT,
     min_derivative=DEFAULT_MIN_DERIVATIVE,
 ):
-    if torch.min(inputs) < left or torch.max(inputs) > right:
+    if len(inputs) != 0 and (torch.min(inputs) < left or torch.max(inputs) > right):
         raise ValueError("Input to a transform is not within its domain")
 
     num_bins = unnormalized_widths.shape[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,16 +5,15 @@ inflect
 jieba
 librosa==0.8.0
 matplotlib
-numpy==1.20.2
+numpy==1.19.5
 pandas
 pypinyin
 pysbd
 pyyaml
-scipy==1.6.3
+scipy>=0.19.0
 soundfile
 tensorboardX
-# torch>=1.7
-torch=1.8.0+cpu
+torch>=1.7
 tqdm
 numba==0.53
 umap-learn==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,16 @@ inflect
 jieba
 librosa==0.8.0
 matplotlib
-numpy==1.19.5
+numpy==1.20.2
 pandas
 pypinyin
 pysbd
 pyyaml
-scipy>=0.19.0
+scipy==1.6.3
 soundfile
 tensorboardX
-torch>=1.7
+# torch>=1.7
+torch=1.8.0+cpu
 tqdm
 numba==0.53
 umap-learn==0.5.1


### PR DESCRIPTION
This is my first time contributing here....
I am sending this PR to address two bugs I found when training my model. 
1. Add input size is not zero before calling torch.min otherwise we will get error. Testing done.
2. Coqui server is reading wrong config file path. Testing change.
 
Error throw: 

```
...
File "/app/lib/python3.7/site-packages/TTS/server/server.py", line 153, in details
    model_config = load_config(args.tts_config)
AttributeError: 'Namespace' object has no attribute 'tts_config'
```
