### PR TITLE
Upgrade scipy dependency to support betabinom

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas
 pypinyin
 pysbd
 pyyaml
-scipy>=0.19.0
+scipy>=1.4.0
 soundfile
 tensorboardX
 torch>=1.7


### PR DESCRIPTION
When launching TTS with the current requirements, TTS may fail due to the too old scipy version declared in requirements:
```
Traceback (most recent call last):
  File "/usr/local/bin/tts", line 33, in <module>
    sys.exit(load_entry_point('TTS', 'console_scripts', 'tts')())
  File "/home/mdalstein/code/TTS/TTS/bin/synthesize.py", line 247, in main
    synthesizer = Synthesizer(
  File "/home/mdalstein/code/TTS/TTS/utils/synthesizer.py", line 78, in __init__
    self._load_tts(tts_checkpoint, tts_config_path, use_cuda)
  File "/home/mdalstein/code/TTS/TTS/utils/synthesizer.py", line 131, in _load_tts
    self.tts_model = setup_tts_model(config=self.tts_config, speaker_manager=speaker_manager)
  File "/home/mdalstein/code/TTS/TTS/tts/models/__init__.py", line 11, in setup_model
    MyModel = find_module("TTS.tts.models", config.model.lower())
  File "/home/mdalstein/code/TTS/TTS/utils/generic_utils.py", line 93, in find_module
    module = importlib.import_module(module_path + "." + module_name)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/mdalstein/code/TTS/TTS/tts/models/tacotron2.py", line 11, in <module>
    from TTS.tts.layers.tacotron.tacotron2 import Decoder, Encoder, Postnet
  File "/home/mdalstein/code/TTS/TTS/tts/layers/tacotron/tacotron2.py", line 5, in <module>
    from .attentions import init_attn
  File "/home/mdalstein/code/TTS/TTS/tts/layers/tacotron/attentions.py", line 2, in <module>
    from scipy.stats import betabinom
ImportError: cannot import name 'betabinom' from 'scipy.stats' (/usr/lib/python3/dist-packages/scipy/stats/__init__.py)
```
Indeed betabinom was only introduced in scipy 1.4.x (see https://github.com/scipy/scipy/blob/maintenance/1.4.x/scipy/stats/__init__.py#L153)

This PR intends to upgrade the requirements according to the supported version.