### PR TITLE
Indicate wav filename

### DIFF
--- a/TTS/utils/audio.py
+++ b/TTS/utils/audio.py
@@ -818,7 +818,7 @@ class AudioProcessor(object):
         elif sr is None:
             # SF is faster than librosa for loading files
             x, sr = sf.read(filename)
-            assert self.sample_rate == sr, "%s vs %s" % (self.sample_rate, sr)
+            assert self.sample_rate == sr, "%s vs %s in %s" % (self.sample_rate, sr, filename)
         else:
             x, sr = librosa.load(filename, sr=sr)
         if self.do_trim_silence:


### PR DESCRIPTION
Before the fix load_wav would just tell that it encountered a wav with an unexpected sample rate.
Now it points to the faulty wav which is useful to spot it and check the parent dataset for other faulty ones.