### PR TITLE
Upgrade numpy to 1.22.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy==1.19.5"]
+requires = ["setuptools", "wheel", "Cython", "numpy==1.22.3"]
 
 [flake8]
 max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # core deps
-numpy==1.19.5
+numpy==1.22.3
 cython
 scipy>=1.4.0
 torch>=1.7


### PR DESCRIPTION
Using an older version of numpy was causing dependency resolution conflicts with other packages. Time to bump.