### PR TITLE
Fix & update WaveRNN vocoder model

### DIFF
--- a/TTS/vocoder/models/wavernn.py
+++ b/TTS/vocoder/models/wavernn.py
@@ -233,6 +233,7 @@ class Wavernn(BaseVocoder):
         else:
             raise RuntimeError("Unknown model mode value - ", self.args.mode)
 
+        self.ap = AudioProcessor(**config.audio.to_dict())
         self.aux_dims = self.args.res_out_dims // 4
 
         if self.args.use_upsample_net:
@@ -571,7 +572,7 @@ class Wavernn(BaseVocoder):
     def test(
         self, assets: Dict, test_loader: "DataLoader", output: Dict  # pylint: disable=unused-argument
     ) -> Tuple[Dict, Dict]:
-        ap = assets["audio_processor"]
+        ap = self.ap
         figures = {}
         audios = {}
         samples = test_loader.dataset.load_test_samples(1)
@@ -587,8 +588,16 @@ class Wavernn(BaseVocoder):
                 }
             )
             audios.update({f"test_{idx}/audio": y_hat})
+            # audios.update({f"real_{idx}/audio": y_hat})
         return figures, audios
-
+    
+    def test_log(
+        self, outputs: Dict, logger: "Logger", assets: Dict, steps: int  # pylint: disable=unused-argument
+    ) -> Tuple[Dict, np.ndarray]:
+        figures, audios = outputs
+        logger.eval_figures(steps, figures)
+        logger.eval_audios(steps, audios, self.ap.sample_rate)
+    
     @staticmethod
     def format_batch(batch: Dict) -> Dict:
         waveform = batch[0]
@@ -605,7 +614,7 @@ class Wavernn(BaseVocoder):
         verbose: bool,
         num_gpus: int,
     ):
-        ap = assets["audio_processor"]
+        ap = self.ap
         dataset = WaveRNNDataset(
             ap=ap,
             items=samples,


### PR DESCRIPTION
Pull request consists of two parts:
* Add logging to dashboard generated audio and spectrogram
* Fix following error:
```python
File /mnt/usernfs/home/iyakovlev/TTS/TTS/vocoder/models/wavernn.py:608, in Wavernn.get_data_loader(self, config, assets, is_eval, samples, verbose, num_gpus)
    599 def get_data_loader(  # pylint: disable=no-self-use
    600     self,
    601     config: Coqpit,
   (...)
    606     num_gpus: int,
    607 ):
--> 608     ap = assets["audio_processor"]
    609     dataset = WaveRNNDataset(
    610         ap=ap,
    611         items=samples,
   (...)
    618         verbose=verbose,
    619     )

KeyError: 'audio_processor'
```