### PR TITLE
Add capacitron v2 model

### DIFF
--- a/TTS/.models.json
+++ b/TTS/.models.json
@@ -130,9 +130,9 @@
                     "license": "apache 2.0",
                     "contact": "adamfroghyar@gmail.com"
                 },
-                "capacitron-t2-c150": {
+                "capacitron-t2-c150_v2": {
                     "description": "Capacitron additions to Tacotron 2 with Capacity at 150 as in https://arxiv.org/pdf/1906.03402.pdf",
-                    "github_rls_url": "https://coqui.gateway.scarf.sh/v0.7.0_models/tts_models--en--blizzard2013--capacitron-t2-c150.zip",
+                    "github_rls_url": "https://coqui.gateway.scarf.sh/v0.7.1_models/tts_models--en--blizzard2013--capacitron-t2-c150_v2.zip",
                     "commit": "d6284e7",
                     "default_vocoder": "vocoder_models/en/blizzard2013/hifigan_v2",
                     "author": "Adam Froghyar @a-froghyar",

--- a/TTS/.models.json
+++ b/TTS/.models.json
@@ -133,7 +133,7 @@
                 "capacitron-t2-c150_v2": {
                     "description": "Capacitron additions to Tacotron 2 with Capacity at 150 as in https://arxiv.org/pdf/1906.03402.pdf",
                     "github_rls_url": "https://coqui.gateway.scarf.sh/v0.7.1_models/tts_models--en--blizzard2013--capacitron-t2-c150_v2.zip",
-                    "commit": "d6284e7",
+                    "commit": "a67039d",
                     "default_vocoder": "vocoder_models/en/blizzard2013/hifigan_v2",
                     "author": "Adam Froghyar @a-froghyar",
                     "license": "apache 2.0",


### PR DESCRIPTION
Add capacitron V2 model to TTS zoo. It's more stable and just as expressive!