### PR TITLE
Remove dependency on pyworld to allow TTS Windows installation

### DIFF
--- a/TTS/utils/audio.py
+++ b/TTS/utils/audio.py
@@ -2,7 +2,6 @@ from typing import Dict, Tuple
 
 import librosa
 import numpy as np
-import pyworld as pw
 import scipy.io.wavfile
 import scipy.signal
 import soundfile as sf
@@ -724,38 +723,6 @@ class AudioProcessor(object):
         if pad_sides == 1:
             return 0, pad
         return pad // 2, pad // 2 + pad % 2
-
-    def compute_f0(self, x: np.ndarray) -> np.ndarray:
-        """Compute pitch (f0) of a waveform using the same parameters used for computing melspectrogram.
-
-        Args:
-            x (np.ndarray): Waveform.
-
-        Returns:
-            np.ndarray: Pitch.
-
-        Examples:
-            >>> WAV_FILE = filename = librosa.util.example_audio_file()
-            >>> from TTS.config import BaseAudioConfig
-            >>> from TTS.utils.audio import AudioProcessor
-            >>> conf = BaseAudioConfig(pitch_fmax=8000)
-            >>> ap = AudioProcessor(**conf)
-            >>> wav = ap.load_wav(WAV_FILE, sr=22050)[:5 * 22050]
-            >>> pitch = ap.compute_f0(wav)
-        """
-        assert self.pitch_fmax is not None, " [!] Set `pitch_fmax` before caling `compute_f0`."
-        # align F0 length to the spectrogram length
-        if len(x) % self.hop_length == 0:
-            x = np.pad(x, (0, self.hop_length // 2), mode="reflect")
-
-        f0, t = pw.dio(
-            x.astype(np.double),
-            fs=self.sample_rate,
-            f0_ceil=self.pitch_fmax,
-            frame_period=1000 * self.hop_length / self.sample_rate,
-        )
-        f0 = pw.stonemask(x.astype(np.double), f0, t, self.sample_rate)
-        return f0
 
     ### Audio Processing ###
     def find_endpoint(self, wav: np.ndarray, min_silence_sec=0.8) -> int:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ umap-learn==0.5.1
 pandas
 # deps for training
 matplotlib
-pyworld==0.2.10 # > 0.2.10 is not p3.10.x compatible
 # coqui stack
 trainer
 # config management

--- a/tests/aux_tests/test_audio_processor.py
+++ b/tests/aux_tests/test_audio_processor.py
@@ -181,10 +181,3 @@ class TestAudio(unittest.TestCase):
         mel_norm = ap.melspectrogram(wav)
         mel_denorm = ap.denormalize(mel_norm)
         assert abs(mel_reference - mel_denorm).max() < 1e-4
-
-    def test_compute_f0(self):  # pylint: disable=no-self-use
-        ap = AudioProcessor(**conf)
-        wav = ap.load_wav(WAV_FILE)
-        pitch = ap.compute_f0(wav)
-        mel = ap.melspectrogram(wav)
-        assert pitch.shape[0] == mel.shape[1]


### PR DESCRIPTION
Remove dependency on `pyworld` package in /requirements.txt and its only usage in TTS/utils/audio.py in the function compute_f0(self, ..) (added this [commit](https://github.com/coqui-ai/TTS/commit/fba257104d776b58ac0bfa86fc3d08727046d1fc)).to allow TTS Windows installation.

Fixes https://github.com/coqui-ai/TTS/issues/1779. The package `pyworld` does not seem to be actively maintained in https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/ and its Windows build is already failing.

Manually tested after the fix, the TTS installation is successful on my device.

There will be another `ImportError: DLL load failed` when I manually tested to execute the following command 

`tts --text "Bonjour tout le monde" --model_name "tts_models/fr/mai/tacotron2-DDC"`

```
...
  File "c:\users\collv\documents\tts\tts\TTS\tts\utils\text\tokenizer.py", line 5, in <module>
    from TTS.tts.utils.text.phonemizers import DEF_LANG_TO_PHONEMIZER, get_phonemizer_by_name
  File "c:\users\collv\documents\tts\tts\TTS\tts\utils\text\phonemizers\__init__.py", line 4, in <module>
    from TTS.tts.utils.text.phonemizers.ja_jp_phonemizer import JA_JP_Phonemizer
  File "c:\users\collv\documents\tts\tts\TTS\tts\utils\text\phonemizers\ja_jp_phonemizer.py", line 3, in <module>
    from TTS.tts.utils.text.japanese.phonemizer import japanese_text_to_phonemes
  File "c:\users\collv\documents\tts\tts\TTS\tts\utils\text\japanese\phonemizer.py", line 7, in <module>
  File "C:\Users\collv\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\MeCab\__init__.py", line 10, in <module>
    from . import _MeCab
ImportError: DLL load failed while importing _MeCab: The specified module could not be found.
```

The `ImportError` is a known issue for the Python package `mecab` in Windows and can be fixed following this guide to copy a `libmecab.dll` into `site-packages\MeCab`
- http://harmonizedai.com/article/mecabdll-load-failed/