### PR TITLE
Update requirements.txt; inflect==5.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ soundfile
 librosa==0.8.0
 numba==0.55.1;python_version<"3.10"
 numba==0.55.2;python_version=="3.10"
-inflect
+inflect==5.6.0
 tqdm
 anyascii
 pyyaml


### PR DESCRIPTION
New inflect version (6.0) depends on pydantic which has some issues irrelevant to 🐸 TTS. (see #1808) 
Force inflect==5.6 (pydantic free) install to solve dependency issue.