### PR TITLE
capacitron training fixes

### DIFF
--- a/TTS/tts/models/base_tts.py
+++ b/TTS/tts/models/base_tts.py
@@ -342,7 +342,7 @@ class BaseTTS(BaseTrainerModel):
             loader = DataLoader(
                 dataset,
                 batch_size=config.eval_batch_size if is_eval else config.batch_size,
-                shuffle=False,  # shuffle is done in the dataset.
+                shuffle=True,  # if there is no other sampler
                 collate_fn=dataset.collate_fn,
                 drop_last=False,  # setting this False might cause issues in AMP training.
                 sampler=sampler,

--- a/TTS/utils/capacitron_optimizer.py
+++ b/TTS/utils/capacitron_optimizer.py
@@ -38,9 +38,9 @@ class CapacitronOptimizer:
         self.param_groups = self.primary_optimizer.param_groups
         self.primary_optimizer.step()
 
-    def zero_grad(self):
-        self.primary_optimizer.zero_grad()
-        self.secondary_optimizer.zero_grad()
+    def zero_grad(self, set_to_none=False):
+        self.primary_optimizer.zero_grad(set_to_none)
+        self.secondary_optimizer.zero_grad(set_to_none)
 
     def load_state_dict(self, state_dict):
         self.primary_optimizer.load_state_dict(state_dict[0])


### PR DESCRIPTION
I needed these changes to get the recipes for capacitron working correctly
* `Trainer` seems to expect `CapacitronOptimizer` to handle `set_to_none` argument
* it appeared that when no special sampler is used, the training set was not being shuffled.

re: the shuffling, these sawtooth patterns appeared in both the step time and loss, but vanished when I set `shuffle=True`
<img width="867" alt="Screenshot 2022-10-18 at 20 38 37" src="https://user-images.githubusercontent.com/4522484/196540050-79d838db-02de-4770-8654-16d5cfdfe17b.png">
