### PR TITLE
Use "formatter" key in the datasets json array

### DIFF
--- a/docs/source/tutorial_for_nervous_beginners.md
+++ b/docs/source/tutorial_for_nervous_beginners.md
@@ -84,7 +84,7 @@ We still support running training from CLI like in the old days. The same traini
         "print_eval": true,
         "mixed_precision": false,
         "output_path": "recipes/ljspeech/glow_tts/",
-        "datasets":[{"name": "ljspeech", "meta_file_train":"metadata.csv", "path": "recipes/ljspeech/LJSpeech-1.1/"}]
+        "datasets":[{"formatter": "ljspeech", "meta_file_train":"metadata.csv", "path": "recipes/ljspeech/LJSpeech-1.1/"}]
     }
     ```
 


### PR DESCRIPTION
Currently if one uses the config.json file provided by the tutorial, this error occurs:
```python
$> CUDA_VISIBLE_DEVICES="0" python TTS/bin/train_tts.py --config_path config.json
Traceback (most recent call last):
  File "TTS/bin/train_tts.py", line 71, in <module>
    main()
  File "TTS/bin/train_tts.py", line 51, in main
    eval_split_size=config.eval_split_size,
  File "/Users/ahmed/dev/TTS/TTS/tts/datasets/__init__.py", line 118, in load_tts_samples
    formatter = _get_formatter_by_name(formatter_name)
  File "/Users/ahmed/dev/TTS/TTS/tts/datasets/__init__.py", line 165, in _get_formatter_by_name
```

The `load_tts_samples()` function is expecting that the `formatter` field is set, the key word 'name' is nowhere to be found.