### PR TITLE
Add Original YourTTS vocabulary on YourTTS recipe for full transfer learning

### DIFF
--- a/recipes/vctk/yourtts/train_yourtts.py
+++ b/recipes/vctk/yourtts/train_yourtts.py
@@ -8,7 +8,7 @@ from TTS.bin.resample import resample_files
 from TTS.config.shared_configs import BaseDatasetConfig
 from TTS.tts.configs.vits_config import VitsConfig
 from TTS.tts.datasets import load_tts_samples
-from TTS.tts.models.vits import Vits, VitsArgs, VitsAudioConfig
+from TTS.tts.models.vits import CharactersConfig, Vits, VitsArgs, VitsAudioConfig
 from TTS.utils.downloaders import download_vctk
 
 torch.set_num_threads(24)
@@ -151,7 +151,19 @@ config = VitsConfig(
     phoneme_language="en",
     compute_input_seq_cache=True,
     add_blank=True,
-    text_cleaner="english_cleaners",
+    text_cleaner="multilingual_cleaners",
+    characters=CharactersConfig(
+        characters_class="TTS.tts.models.vits.VitsCharacters",
+        pad="_",
+        eos="&",
+        bos="*",
+        blank=None,
+        characters="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\u00af\u00b7\u00df\u00e0\u00e1\u00e2\u00e3\u00e4\u00e6\u00e7\u00e8\u00e9\u00ea\u00eb\u00ec\u00ed\u00ee\u00ef\u00f1\u00f2\u00f3\u00f4\u00f5\u00f6\u00f9\u00fa\u00fb\u00fc\u00ff\u0101\u0105\u0107\u0113\u0119\u011b\u012b\u0131\u0142\u0144\u014d\u0151\u0153\u015b\u016b\u0171\u017a\u017c\u01ce\u01d0\u01d2\u01d4\u0430\u0431\u0432\u0433\u0434\u0435\u0436\u0437\u0438\u0439\u043a\u043b\u043c\u043d\u043e\u043f\u0440\u0441\u0442\u0443\u0444\u0445\u0446\u0447\u0448\u0449\u044a\u044b\u044c\u044d\u044e\u044f\u0451\u0454\u0456\u0457\u0491\u2013!'(),-.:;? ",
+        punctuations="!'(),-.:;? ",
+        phonemes="",
+        is_unique=True,
+        is_sorted=True,
+    ),
     phoneme_cache_path=None,
     precompute_num_workers=12,
     start_by_longest=True,


### PR DESCRIPTION
@erogol I checked now that the YourTTS recipe is using the default vocabulary (only English).  I think that using the original YourTTS vocabulary is better for the YourTTS recipe because probably the users will try to change the vocabulary and in this way, we already have an example.