### PR TITLE
Update espeak_wrapper.py 

### DIFF
--- a/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
@@ -176,6 +176,10 @@ class ESpeak(BasePhonemizer):
                 args.append("--ipa=1")
         if tie:
             args.append("--tie=%s" % tie)
+           
+        # espeak crash on this string: https://sourceforge.net/p/espeak/mailman/message/27000413/
+        # working on espeak & espeak-ng both
+        args.append(" -- ")
 
         args.append('"' + text + '"')
         # compute phonemes


### PR DESCRIPTION
espeak crashed for non-English languages like Tamil, and Telugu if backend espeak-ng installed. telugu not having espeak support. so i fixed it with espeak-ng. 

So I followed this fix (https://sourceforge.net/p/espeak/mailman/message/27000413/)

It worked fine for both espeak & espeak-ng both 