### PR TITLE
Fixed PE

### DIFF
--- a/TTS/tts/layers/generic/pos_encoding.py
+++ b/TTS/tts/layers/generic/pos_encoding.py
@@ -18,8 +18,7 @@ class PositionalEncoding(nn.Module):
         super().__init__()
         if channels % 2 != 0:
             raise ValueError(
-                "Cannot use sin/cos positional encoding with "
-                "odd channels (got channels={:d})".format(channels)
+                "Cannot use sin/cos positional encoding with " "odd channels (got channels={:d})".format(channels)
             )
         self.use_scale = use_scale
         if use_scale:
@@ -27,9 +26,7 @@ class PositionalEncoding(nn.Module):
         pe = torch.zeros(max_len, channels)
         position = torch.arange(0, max_len).unsqueeze(1)
         # div_term = torch.pow(10000, torch.arange(0, channels, 2).float() / channels)
-        div_term = torch.exp(
-            torch.arange(0, channels, 2).float() * -(math.log(10000.0) / channels)
-        )
+        div_term = torch.exp(torch.arange(0, channels, 2).float() * -(math.log(10000.0) / channels))
         pe[:, 0::2] = torch.sin(position.float() * div_term)
         pe[:, 1::2] = torch.cos(position.float() * div_term)
         pe = pe.unsqueeze(0).transpose(1, 2)

--- a/TTS/tts/layers/generic/pos_encoding.py
+++ b/TTS/tts/layers/generic/pos_encoding.py
@@ -7,7 +7,6 @@ from torch import nn
 class PositionalEncoding(nn.Module):
     """Sinusoidal positional encoding for non-recurrent neural networks.
     Implementation based on "Attention Is All You Need"
-
     Args:
        channels (int): embedding size
        dropout_p (float): dropout rate applied to the output.
@@ -19,14 +18,18 @@ class PositionalEncoding(nn.Module):
         super().__init__()
         if channels % 2 != 0:
             raise ValueError(
-                "Cannot use sin/cos positional encoding with " "odd channels (got channels={:d})".format(channels)
+                "Cannot use sin/cos positional encoding with "
+                "odd channels (got channels={:d})".format(channels)
             )
         self.use_scale = use_scale
         if use_scale:
             self.scale = torch.nn.Parameter(torch.ones(1))
         pe = torch.zeros(max_len, channels)
         position = torch.arange(0, max_len).unsqueeze(1)
-        div_term = torch.pow(10000, torch.arange(0, channels, 2).float() / channels)
+        # div_term = torch.pow(10000, torch.arange(0, channels, 2).float() / channels)
+        div_term = torch.exp(
+            torch.arange(0, channels, 2).float() * -(math.log(10000.0) / channels)
+        )
         pe[:, 0::2] = torch.sin(position.float() * div_term)
         pe[:, 1::2] = torch.cos(position.float() * div_term)
         pe = pe.unsqueeze(0).transpose(1, 2)

--- a/TTS/vocoder/layers/wavegrad.py
+++ b/TTS/vocoder/layers/wavegrad.py
@@ -26,18 +26,12 @@ class PositionalEncoding(nn.Module):
     def forward(self, x, noise_level):
         if x.shape[2] > self.pe.shape[1]:
             self.init_pe_matrix(x.shape[1], x.shape[2], x)
-        return (
-            x
-            + noise_level[..., None, None]
-            + self.pe[:, : x.size(2)].repeat(x.shape[0], 1, 1) / self.C
-        )
+        return x + noise_level[..., None, None] + self.pe[:, : x.size(2)].repeat(x.shape[0], 1, 1) / self.C
 
     def init_pe_matrix(self, n_channels, max_len, x):
         pe = torch.zeros(max_len, n_channels)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
-        div_term = torch.exp(
-            torch.arange(0, n_channels, 2).float() * -(math.log(10000.0) / n_channels)
-        )
+        div_term = torch.exp(torch.arange(0, n_channels, 2).float() * -(math.log(10000.0) / n_channels))
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
         self.pe = pe.transpose(0, 1).to(x)

--- a/TTS/vocoder/layers/wavegrad.py
+++ b/TTS/vocoder/layers/wavegrad.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -24,15 +26,20 @@ class PositionalEncoding(nn.Module):
     def forward(self, x, noise_level):
         if x.shape[2] > self.pe.shape[1]:
             self.init_pe_matrix(x.shape[1], x.shape[2], x)
-        return x + noise_level[..., None, None] + self.pe[:, : x.size(2)].repeat(x.shape[0], 1, 1) / self.C
+        return (
+            x
+            + noise_level[..., None, None]
+            + self.pe[:, : x.size(2)].repeat(x.shape[0], 1, 1) / self.C
+        )
 
     def init_pe_matrix(self, n_channels, max_len, x):
         pe = torch.zeros(max_len, n_channels)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
-        div_term = torch.pow(10000, torch.arange(0, n_channels, 2).float() / n_channels)
-
-        pe[:, 0::2] = torch.sin(position / div_term)
-        pe[:, 1::2] = torch.cos(position / div_term)
+        div_term = torch.exp(
+            torch.arange(0, n_channels, 2).float() * -(math.log(10000.0) / n_channels)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
         self.pe = pe.transpose(0, 1).to(x)
 
 
@@ -80,14 +87,38 @@ class UBlock(nn.Module):
         self.res_block = Conv1d(input_size, hidden_size, 1)
         self.main_block = nn.ModuleList(
             [
-                Conv1d(input_size, hidden_size, 3, dilation=dilation[0], padding=dilation[0]),
-                Conv1d(hidden_size, hidden_size, 3, dilation=dilation[1], padding=dilation[1]),
+                Conv1d(
+                    input_size,
+                    hidden_size,
+                    3,
+                    dilation=dilation[0],
+                    padding=dilation[0],
+                ),
+                Conv1d(
+                    hidden_size,
+                    hidden_size,
+                    3,
+                    dilation=dilation[1],
+                    padding=dilation[1],
+                ),
             ]
         )
         self.out_block = nn.ModuleList(
             [
-                Conv1d(hidden_size, hidden_size, 3, dilation=dilation[2], padding=dilation[2]),
-                Conv1d(hidden_size, hidden_size, 3, dilation=dilation[3], padding=dilation[3]),
+                Conv1d(
+                    hidden_size,
+                    hidden_size,
+                    3,
+                    dilation=dilation[2],
+                    padding=dilation[2],
+                ),
+                Conv1d(
+                    hidden_size,
+                    hidden_size,
+                    3,
+                    dilation=dilation[3],
+                    padding=dilation[3],
+                ),
             ]
         )
 


### PR DESCRIPTION
rewrite (1000**(i/channels)) as exp(log(1000**(i/channels)) = exp((i/channels)*(log(1000))) == exp(i * (log(1000)/channels)) then The minus sign comes in the edited code because it is in denominator.

![image](https://user-images.githubusercontent.com/8834712/209767295-50e83571-98ab-43a2-a0ae-298a36c37930.png)
![image](https://user-images.githubusercontent.com/8834712/209893371-a731ad92-b70d-4e24-a990-a412b171e1a6.png)
The 'dmodel' in image is 'channels' in our code.
Also, did we always forget to invert when multiplying the `div_term`  ?? 😮 
Although, we do divide in wavegrad.py 😌 
(see [wavegrad.py](https://github.com/p0p4k/TTS/blob/e5731fe0d1a33f6fc5f96f68aed2a819f3adf0b9/TTS/vocoder/layers/wavegrad.py#L34-L35))

lastly, optimization :
 
![image](https://user-images.githubusercontent.com/8834712/209768506-f9a7df4c-f751-424b-8f82-70e2ecb6c348.png)
![image](https://user-images.githubusercontent.com/8834712/209768564-e06e3c4d-d5b4-4e9f-9233-936f9fd180f6.png)