### PR TITLE
Change default vocoder for the pretrained glowtts model to univnet

### DIFF
--- a/TTS/.models.json
+++ b/TTS/.models.json
@@ -100,7 +100,7 @@
                     "description": "",
                     "github_rls_url": "https://coqui.gateway.scarf.sh/v0.6.1_models/tts_models--en--ljspeech--glow-tts.zip",
                     "stats_file": null,
-                    "default_vocoder": "vocoder_models/en/ljspeech/multiband-melgan",
+                    "default_vocoder": "vocoder_models/en/ljspeech/univnet",
                     "commit": "",
                     "author": "Eren Gölge @erogol",
                     "license": "MPL",


### PR DESCRIPTION
…t: Provides highest quality upon personal testing. Note: pitch and pronunciattion problems stem from glow tts. The change only improves clarity of speech