### PR TITLE
Use packaging.version for version comparisons

### DIFF
--- a/TTS/bin/resample.py
+++ b/TTS/bin/resample.py
@@ -2,8 +2,8 @@ import argparse
 import glob
 import os
 from argparse import RawTextHelpFormatter
-from distutils.dir_util import copy_tree
 from multiprocessing import Pool
+from shutil import copytree
 
 import librosa
 import soundfile as sf
@@ -19,7 +19,7 @@ def resample_file(func_args):
 def resample_files(input_dir, output_sr, output_dir=None, file_ext="wav", n_jobs=10):
     if output_dir:
         print("Recursively copying the input folder...")
-        copy_tree(input_dir, output_dir)
+        copytree(input_dir, output_dir)
         input_dir = output_dir
 
     print("Resampling the audio files...")

--- a/TTS/tts/layers/glow_tts/glow.py
+++ b/TTS/tts/layers/glow_tts/glow.py
@@ -1,6 +1,5 @@
-from distutils.version import LooseVersion
-
 import torch
+from packaging.version import Version
 from torch import nn
 from torch.nn import functional as F
 
@@ -91,7 +90,7 @@ class InvConvNear(nn.Module):
         self.no_jacobian = no_jacobian
         self.weight_inv = None
 
-        if LooseVersion(torch.__version__) < LooseVersion("1.9"):
+        if Version(torch.__version__) < Version("1.9"):
             w_init = torch.qr(torch.FloatTensor(self.num_splits, self.num_splits).normal_())[0]
         else:
             w_init = torch.linalg.qr(torch.FloatTensor(self.num_splits, self.num_splits).normal_(), "complete")[0]

--- a/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
@@ -1,8 +1,9 @@
 import logging
 import re
 import subprocess
-from distutils.version import LooseVersion
 from typing import Dict, List
+
+from packaging.version import Version
 
 from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.punctuation import Punctuation
@@ -168,7 +169,7 @@ class ESpeak(BasePhonemizer):
         else:
             # split with '_'
             if self.backend == "espeak":
-                if LooseVersion(self.backend_version) >= LooseVersion("1.48.15"):
+                if Version(self.backend_version) >= Version("1.48.15"):
                     args.append("--ipa=1")
                 else:
                     args.append("--ipa=3")

--- a/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
@@ -15,9 +15,16 @@ def is_tool(name):
     return which(name) is not None
 
 
+# Use a regex pattern to match the espeak version, because it may be
+# symlinked to espeak-ng, which moves the version bits to another spot.
+espeak_version_pattern = re.compile(r"text-to-speech:\s(?P<version>\d+\.\d+(\.\d+)?)")
+
+
 def get_espeak_version():
     output = subprocess.getoutput("espeak --version")
-    return output.split()[2]
+    match = espeak_version_pattern.search(output)
+
+    return match.group("version")
 
 
 def get_espeakng_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython==0.29.28", "numpy==1.21.6"]
+requires = ["setuptools", "wheel", "cython==0.29.28", "numpy==1.21.6", "packaging"]
 
 [flake8]
 max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ tqdm
 anyascii
 pyyaml
 fsspec>=2021.04.0
+packaging
 # deps for examples
 flask
 # deps for inference

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 import os
 import subprocess
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy
 import setuptools.command.build_py
@@ -31,7 +31,8 @@ import setuptools.command.develop
 from Cython.Build import cythonize
 from setuptools import Extension, find_packages, setup
 
-if LooseVersion(sys.version) < LooseVersion("3.7") or LooseVersion(sys.version) >= LooseVersion("3.11"):
+python_version = sys.version.split()[0]
+if Version(python_version) < Version("3.7") or Version(python_version) >= Version("3.11"):
     raise RuntimeError("TTS requires python >= 3.7 and < 3.11 " "but your Python version is {}".format(sys.version))
 
 

--- a/tests/text_tests/test_phonemizer.py
+++ b/tests/text_tests/test_phonemizer.py
@@ -1,5 +1,6 @@
 import unittest
-from distutils.version import LooseVersion
+
+from packaging.version import Version
 
 from TTS.tts.utils.text.phonemizers import ESpeak, Gruut, JA_JP_Phonemizer, ZH_CN_Phonemizer
 from TTS.tts.utils.text.phonemizers.multi_phonemizer import MultiPhonemizer
@@ -40,7 +41,7 @@ class TestEspeakPhonemizer(unittest.TestCase):
     def setUp(self):
         self.phonemizer = ESpeak(language="en-us", backend="espeak")
 
-        if LooseVersion(self.phonemizer.backend_version) >= LooseVersion("1.48.15"):
+        if Version(self.phonemizer.backend_version) >= Version("1.48.15"):
             target_phonemes = EXPECTED_ESPEAK_v1_48_15_PHONEMES
         else:
             target_phonemes = EXPECTED_ESPEAK_PHONEMES
@@ -52,7 +53,7 @@ class TestEspeakPhonemizer(unittest.TestCase):
         # multiple punctuations
         text = "Be a voice, not an! echo?"
         gt = "biː ɐ vˈɔɪs, nˈɑːt ɐn! ˈɛkoʊ?"
-        if LooseVersion(self.phonemizer.backend_version) >= LooseVersion("1.48.15"):
+        if Version(self.phonemizer.backend_version) >= Version("1.48.15"):
             gt = "biː ɐ vˈɔɪs, nˈɑːt æn! ˈɛkoʊ?"
         output = self.phonemizer.phonemize(text, separator="|")
         output = output.replace("|", "")
@@ -61,7 +62,7 @@ class TestEspeakPhonemizer(unittest.TestCase):
         # not ending with punctuation
         text = "Be a voice, not an! echo"
         gt = "biː ɐ vˈɔɪs, nˈɑːt ɐn! ˈɛkoʊ"
-        if LooseVersion(self.phonemizer.backend_version) >= LooseVersion("1.48.15"):
+        if Version(self.phonemizer.backend_version) >= Version("1.48.15"):
             gt = "biː ɐ vˈɔɪs, nˈɑːt æn! ˈɛkoʊ"
         output = self.phonemizer.phonemize(text, separator="")
         self.assertEqual(output, gt)
@@ -69,7 +70,7 @@ class TestEspeakPhonemizer(unittest.TestCase):
         # extra space after the sentence
         text = "Be a voice, not an! echo.  "
         gt = "biː ɐ vˈɔɪs, nˈɑːt ɐn! ˈɛkoʊ."
-        if LooseVersion(self.phonemizer.backend_version) >= LooseVersion("1.48.15"):
+        if Version(self.phonemizer.backend_version) >= Version("1.48.15"):
             gt = "biː ɐ vˈɔɪs, nˈɑːt æn! ˈɛkoʊ."
         output = self.phonemizer.phonemize(text, separator="")
         self.assertEqual(output, gt)


### PR DESCRIPTION
The distutils package is deprecated¹ and relies on PEP 386² version
comparisons, which have been superseded by PEP 440³ which is implemented
through the packaging module.

With more recent distutils versions, provided through setuptools
vendoring, we are seeing the following exception during version
comparisons:

> TypeError: '<' not supported between instances of 'str' and 'int'

This problem stems from improper version detection in the espeak wrapper,
fixed in a second commit.

A third commit removes the only remaining usage of distutils thereafter.

[1] https://docs.python.org/3/library/distutils.html
[2] https://peps.python.org/pep-0386/
[3] https://peps.python.org/pep-0440/