### PR TITLE
fixed tts_to_file throwing error when TTS object is constructed without model_name

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -303,6 +303,8 @@ class TTS:
 
     @property
     def is_coqui_studio(self):
+        if(self.model_name is None):
+            return False
         return "coqui_studio" in self.model_name
 
     @property

--- a/TTS/api.py
+++ b/TTS/api.py
@@ -303,7 +303,7 @@ class TTS:
 
     @property
     def is_coqui_studio(self):
-        if(self.model_name is None):
+        if self.model_name is None:
             return False
         return "coqui_studio" in self.model_name
 


### PR DESCRIPTION
when constructing TTS object with model_path and config_path 

`tts = TTS(model_path=f"{special_path}/{model}", config_path=f"{special_path}/config.json", progress_bar=False, gpu=False)`

and then trying to do some text-to-speech

`tts.tts_to_file(text, speaker_wav=voice_path ,file_path=output, language="en")`

I get an error

_Traceback (most recent call last):
  File "/home/akmere/Projects/TTS/index.py", line 52, in <module>
    tts.tts_to_file(text, speaker_wav=voice_path ,file_path=output, language="en")
  File "/home/akmere/Projects/TTS/TTS/api.py", line 556, in tts_to_file
    self._check_arguments(speaker=speaker, language=language, speaker_wav=speaker_wav)
  File "/home/akmere/Projects/TTS/TTS/api.py", line 414, in _check_arguments
    if not self.is_coqui_studio:
  File "/home/akmere/Projects/TTS/TTS/api.py", line 296, in is_coqui_studio
    return "coqui_studio" in self.model_name
TypeError: argument of type 'NoneType' is not iterable_

