### PR TITLE
Treat case when model has no model_name

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -303,7 +303,7 @@ class TTS:
 
     @property
     def is_coqui_studio(self):
-        return "coqui_studio" in self.model_name
+        return "coqui_studio" in self.model_name if self.model_name is not None else False
 
     @property
     def is_multi_lingual(self):


### PR DESCRIPTION
Is coqui studio property could not return False if model_name was not set.
This is related to https://github.com/coqui-ai/TTS/issues/2525