### PR TITLE
use default_factory for audio parameter

### DIFF
--- a/TTS/tts/configs/vits_config.py
+++ b/TTS/tts/configs/vits_config.py
@@ -109,7 +109,7 @@ class VitsConfig(BaseTTSConfig):
     model: str = "vits"
     # model specific params
     model_args: VitsArgs = field(default_factory=VitsArgs)
-    audio: VitsAudioConfig = VitsAudioConfig()
+    audio: VitsAudioConfig = field(default_factory=VitsAudioConfig)
 
     # optimizer
     grad_clip: List[float] = field(default_factory=lambda: [1000, 1000])


### PR DESCRIPTION
Python 3.11 complains about the mutable default and other members were already adapted to use the factory, so I expect this line just went unnoticed until now.

This is the only line I needed to change to get the default speech-synthesis to work in python3.11.
Aside from unpinning dependencies of course.