### PR TITLE
Singular speaker model with embedding file

### DIFF
--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -252,11 +252,8 @@ class Synthesizer(object):
         speaker_embedding = None
         speaker_id = None
         if self.tts_speakers_file or hasattr(self.tts_model.speaker_manager, "name_to_id"):
-            # handle Neon models with single speaker.
-            if len(self.tts_model.speaker_manager.name_to_id) == 1:
-                speaker_id = list(self.tts_model.speaker_manager.name_to_id.values())[0]
-
-            elif speaker_name and isinstance(speaker_name, str):
+            
+            if speaker_name and isinstance(speaker_name, str):
                 if self.tts_config.use_d_vector_file:
                     # get the average speaker embedding from the saved d_vectors.
                     speaker_embedding = self.tts_model.speaker_manager.get_mean_embedding(
@@ -266,7 +263,9 @@ class Synthesizer(object):
                 else:
                     # get speaker idx from the speaker name
                     speaker_id = self.tts_model.speaker_manager.name_to_id[speaker_name]
-
+            # handle Neon models with single speaker.
+            elif len(self.tts_model.speaker_manager.name_to_id) == 1:
+                speaker_id = list(self.tts_model.speaker_manager.name_to_id.values())[0]
             elif not speaker_name and not speaker_wav:
                 raise ValueError(
                     " [!] Looks like you are using a multi-speaker model. "


### PR DESCRIPTION
It looks like the Neon model is special in that t does not have a speaker_name and it wants to get the only item available. 
This was blocking a valid model with one speaker and a d_vector_file from being executed to get the embedding.

Leaving the check to be second still works fine for the case that there is only one model and no speaker name.

This is in reference to bug 2320
https://github.com/coqui-ai/TTS/issues/2320