### PR TITLE
Failed to download the file and need to delete the created file path

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -292,15 +292,20 @@ class ModelManager(object):
         else:
             os.makedirs(output_path, exist_ok=True)
             print(f" > Downloading model to {output_path}")
-            # download from fairseq
-            if "fairseq" in model_name:
-                self.download_fairseq_model(model_name, output_path)
-            else:
-                # download from github release
-                if isinstance(model_item["github_rls_url"], list):
-                    self._download_model_files(model_item["github_rls_url"], output_path, self.progress_bar)
+            try:
+                # download from fairseq
+                if "fairseq" in model_name:
+                    self.download_fairseq_model(model_name, output_path)
                 else:
-                    self._download_zip_file(model_item["github_rls_url"], output_path, self.progress_bar)
+                    # download from github release
+                    if isinstance(model_item["github_rls_url"], list):
+                        self._download_model_files(model_item["github_rls_url"], output_path, self.progress_bar)
+                    else:
+                        self._download_zip_file(model_item["github_rls_url"], output_path, self.progress_bar)
+            except requests.Exception.RequestException as e:
+                print(f" > Failed to download the model file to {output_path}")
+                rmtree(output_path)
+                raise e
             self.print_model_license(model_item=model_item)
         # find downloaded files
         output_model_path = output_path


### PR DESCRIPTION
I noticed that when the download of the model file fails, the folder of the model file will still be kept, and when I execute the CLI command again, it will be judged that the model has been downloaded because of the existence of this folder, which will eventually lead to ValueError: [!] Model file not found in the output path. So I want to fix it with this change
![image](https://github.com/coqui-ai/TTS/assets/41884581/6e8eb9f1-b0b0-47ca-8519-1e65e10ac1a2)
