### PR TITLE
Update compute_embeddings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - 📣 You can use [~1100 Fairseq models](https://github.com/facebookresearch/fairseq/tree/main/examples/mms) with 🐸TTS.
 - 📣 🐸TTS now supports 🐢Tortoise with faster inference.
 - 📣 **Coqui Studio API** is landed on 🐸TTS. - [Example](https://github.com/coqui-ai/TTS/blob/dev/README.md#-python-api)
-- 📣 [**Coqui Sudio API**](https://docs.coqui.ai/docs) is live.
+- 📣 [**Coqui Studio API**](https://docs.coqui.ai/docs) is live.
 - 📣 Voice generation with prompts - **Prompt to Voice** - is live on [**Coqui Studio**](https://app.coqui.ai/auth/signin)!! - [Blog Post](https://coqui.ai/blog/tts/prompt-to-voice)
 - 📣 Voice generation with fusion - **Voice fusion** - is live on [**Coqui Studio**](https://app.coqui.ai/auth/signin).
 - 📣 Voice cloning is live on [**Coqui Studio**](https://app.coqui.ai/auth/signin).

--- a/TTS/bin/compute_embeddings.py
+++ b/TTS/bin/compute_embeddings.py
@@ -16,7 +16,7 @@ def compute_embeddings(
     model_path,
     config_path,
     output_path,
-    old_spakers_file=None,
+    old_speakers_file=None,
     config_dataset_path=None,
     formatter_name=None,
     dataset_name=None,
@@ -50,7 +50,7 @@ def compute_embeddings(
     encoder_manager = SpeakerManager(
         encoder_model_path=model_path,
         encoder_config_path=config_path,
-        d_vectors_file_path=old_spakers_file,
+        d_vectors_file_path=old_speakers_file,
         use_cuda=use_cuda,
     )
 
@@ -63,7 +63,7 @@ def compute_embeddings(
         audio_file = fields["audio_file"]
         embedding_key = fields["audio_unique_name"]
 
-        if old_spakers_file is not None and embedding_key in encoder_manager.clip_ids:
+        if old_speakers_file is not None and embedding_key in encoder_manager.clip_ids:
             # get the embedding from the old file
             embedd = encoder_manager.get_embedding_by_clip(embedding_key)
         else:
@@ -118,12 +118,25 @@ if __name__ == "__main__":
         help="Path to dataset config file. You either need to provide this or `formatter_name`, `dataset_name` and `dataset_path` arguments.",
         default=None,
     )
-    parser.add_argument("--output_path", type=str, help="Path for output `pth` or `json` file.", default="speakers.pth")
     parser.add_argument(
-        "--old_file", type=str, help="Previous embedding file to only compute new audios.", default=None
+        "--output_path",
+        type=str,
+        help="Path for output `pth` or `json` file.",
+        default="speakers.pth",
+    )
+    parser.add_argument(
+        "--old_file",
+        type=str,
+        help="The old existing embedding file, into which the embedding of new audio clips will be computed and inserted.",
+        default=None,
     )
     parser.add_argument("--disable_cuda", type=bool, help="Flag to disable cuda.", default=False)
-    parser.add_argument("--no_eval", type=bool, help="Do not compute eval?. Default False", default=False)
+    parser.add_argument(
+        "--no_eval",
+        type=bool,
+        help="Do not compute eval?. Default False",
+        default=False,
+    )
     parser.add_argument(
         "--formatter_name",
         type=str,
@@ -160,7 +173,7 @@ if __name__ == "__main__":
         args.model_path,
         args.config_path,
         args.output_path,
-        old_spakers_file=args.old_file,
+        old_speakers_file=args.old_file,
         config_dataset_path=args.config_dataset_path,
         formatter_name=args.formatter_name,
         dataset_name=args.dataset_name,

--- a/TTS/bin/compute_embeddings.py
+++ b/TTS/bin/compute_embeddings.py
@@ -103,11 +103,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""Compute embedding vectors for each audio file in a dataset and store them keyed by `{dataset_name}#{file_path}` in a .pth file\n\n"""
         """
-                    Example runs:
-                    python TTS/bin/compute_embeddings.py --model_path speaker_encoder_model.pth --config_path speaker_encoder_config.json  --config_dataset_path dataset_config.json
-            
-                    python TTS/bin/compute_embeddings.py --model_path speaker_encoder_model.pth --config_path speaker_encoder_config.json  --formatter_name coqui --dataset_path /path/to/vctk/dataset --dataset_name my_vctk --meta_file_train /path/to/vctk/metafile_train.csv --meta_file_val /path/to/vctk/metafile_eval.csv
-                    """,
+        Example runs:
+        python TTS/bin/compute_embeddings.py --model_path speaker_encoder_model.pth --config_path speaker_encoder_config.json  --config_dataset_path dataset_config.json
+
+        python TTS/bin/compute_embeddings.py --model_path speaker_encoder_model.pth --config_path speaker_encoder_config.json  --formatter_name coqui --dataset_path /path/to/vctk/dataset --dataset_name my_vctk --meta_file_train /path/to/vctk/metafile_train.csv --meta_file_val /path/to/vctk/metafile_eval.csv
+        """,
         formatter_class=RawTextHelpFormatter,
     )
     parser.add_argument(

--- a/recipes/vctk/yourtts/train_yourtts.py
+++ b/recipes/vctk/yourtts/train_yourtts.py
@@ -99,7 +99,7 @@ for dataset_conf in DATASETS_CONFIG_LIST:
             SPEAKER_ENCODER_CHECKPOINT_PATH,
             SPEAKER_ENCODER_CONFIG_PATH,
             embeddings_file,
-            old_spakers_file=None,
+            old_speakers_file=None,
             config_dataset_path=None,
             formatter_name=dataset_conf.formatter,
             dataset_name=dataset_conf.dataset_name,


### PR DESCRIPTION
- Fix typo in variable name. 
- Add more readable description for `old_file` parameter.
- Add `old_append` parameter to enable append new embedding into the existing old one.
- Fix `argparser` for `bool` value.