### PR TITLE
fixed Index OOB issue with ljspeech formatter

### DIFF
--- a/TTS/tts/datasets/formatters.py
+++ b/TTS/tts/datasets/formatters.py
@@ -159,7 +159,7 @@ def ljspeech(root_path, meta_file, **kwargs):  # pylint: disable=unused-argument
         for line in ttf:
             cols = line.split("|")
             wav_file = os.path.join(root_path, "wavs", cols[0] + ".wav")
-            text = cols[2]
+            text = cols[1]
             items.append({"text": text, "audio_file": wav_file, "speaker_name": speaker_name, "root_path": root_path})
     return items
 


### PR DESCRIPTION
got an index out of range error when using ljspeech formatter when metadata.txt is in recommended format as per this link
https://tts.readthedocs.io/en/latest/formatting_your_dataset.html

```
# metadata.txt

audio1|This is my sentence.
audio2|This is maybe my sentence.
audio3|This is certainly my sentence.
audio4|Let this be your sentence.
...
```