### PR TITLE
Adds multispeaker support to inference_onnx with VITS, makes onnx inference faster

### DIFF
--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -1875,7 +1875,7 @@ class Vits(BaseTTS):
     def load_onnx(self, model_path: str, cuda=False):
         import onnxruntime as ort
 
-        providers = ["CPUExecutionProvider" if cuda is False else "CUDAExecutionProvider"]
+        providers = ["CPUExecutionProvider" if cuda is False else ("CUDAExecutionProvider", {"cudnn_conv_algo_search": "DEFAULT"})]
         sess_options = ort.SessionOptions()
         self.onnx_sess = ort.InferenceSession(
             model_path,
@@ -1883,10 +1883,8 @@ class Vits(BaseTTS):
             providers=providers,
         )
 
-    def inference_onnx(self, x, x_lengths=None):
-        """ONNX inference (only single speaker models are supported)
-
-        TODO: implement multi speaker support.
+    def inference_onnx(self, x, x_lengths=None, speaker_id=None):
+        """ONNX inference
         """
 
         if isinstance(x, torch.Tensor):
@@ -1907,7 +1905,7 @@ class Vits(BaseTTS):
                 "input": x,
                 "input_lengths": x_lengths,
                 "scales": scales,
-                "sid": None,
+                "sid": torch.tensor([speaker_id]).cpu().numpy(),
             },
         )
         return audio[0][0]


### PR DESCRIPTION
Adjusts the provider choice for CUDAExecutionProvider based on https://github.com/microsoft/onnxruntime/issues/12880#issuecomment-1336147260 and https://github.com/coqui-ai/TTS/pull/2563#issuecomment-1552100306

Fixed onnx inference to support multispeaker.

Benched it against a personal multispeaker model with the following setup:
```
time_list = []
text_inputs_list = []
num_speakers = range(265)
print("Beginning 500 32 buffalo random-speaker inference test with text inputs calc'd each time")
for i in range(500):
    starttime = time.time()
    text = "Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo Buffalo."
    text_inputs = np.asarray(
        vits.tokenizer.text_to_ids(text, language="en"),
        dtype=np.int64,
    )[None, :]
    text_inputs_list.append(time.time()-starttime)
    starttime = time.time()
    audio = vits.inference_onnx(text_inputs, speaker_id=random.choice(num_speakers))
    time_list.append(time.time()-starttime)
    save_wav(wav=audio[0], path="./buffalo_samples/coqui_vits _" + str(i) + ".wav", sample_rate=config.audio.sample_rate)
print("Mean text_inputs time: " + str(statistics.mean(text_inputs_list)))
print("Mean inference time: " + str(statistics.mean(time_list)))
print("Total inference time: " + str(sum(time_list))))
```

We were able to generate 2 hours and 15 minutes of roughly 15-20 second clips within 32 seconds on an RTX 4080 using this setup.