### PR TITLE
Make Japanese-specific dependencies optional

### DIFF
--- a/TTS/tts/utils/text/japanese/phonemizer.py
+++ b/TTS/tts/utils/text/japanese/phonemizer.py
@@ -4,7 +4,10 @@
 import re
 import unicodedata
 
-import MeCab
+try:
+    import MeCab
+except ImportError:
+    raise ImportError("Japanese requires mecab-python3 and unidic-lite.")
 from num2words import num2words
 
 _CONVRULES = [

--- a/requirements.ja.txt
+++ b/requirements.ja.txt
@@ -1,0 +1,3 @@
+# japanese g2p deps
+mecab-python3==1.0.6
+unidic-lite==1.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,9 +32,6 @@ coqpit>=0.0.16
 # chinese g2p deps
 jieba
 pypinyin
-# japanese g2p deps
-#mecab-python3==1.0.6
-#unidic-lite==1.0.8
 # gruut+supported langs
 gruut[de,es,fr]==2.2.3
 # deps for korean

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,8 @@ coqpit>=0.0.16
 jieba
 pypinyin
 # japanese g2p deps
-mecab-python3==1.0.6
-unidic-lite==1.0.8
+#mecab-python3==1.0.6
+#unidic-lite==1.0.8
 # gruut+supported langs
 gruut[de,es,fr]==2.2.3
 # deps for korean

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open(os.path.join(cwd, "requirements.dev.txt"), "r") as f:
     requirements_dev = f.readlines()
 with open(os.path.join(cwd, "requirements.ja.txt"), "r") as f:
     requirements_ja = f.readlines()
-requirements_all = requirements_dev + requirements_notebooks
+requirements_all = requirements_dev + requirements_notebooks + requirements_ja
 
 with open("README.md", "r", encoding="utf-8") as readme_file:
     README = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ with open(os.path.join(cwd, "requirements.notebooks.txt"), "r") as f:
     requirements_notebooks = f.readlines()
 with open(os.path.join(cwd, "requirements.dev.txt"), "r") as f:
     requirements_dev = f.readlines()
+with open(os.path.join(cwd, "requirements.ja.txt"), "r") as f:
+    requirements_ja = f.readlines()
 requirements_all = requirements_dev + requirements_notebooks
 
 with open("README.md", "r", encoding="utf-8") as readme_file:
@@ -113,6 +115,7 @@ setup(
         "all": requirements_all,
         "dev": requirements_dev,
         "notebooks": requirements_notebooks,
+        "ja": requirements_ja,
     },
     python_requires=">=3.9.0, <3.12",
     entry_points={"console_scripts": ["tts=TTS.bin.synthesize:main", "tts-server = TTS.server.server:main"]},


### PR DESCRIPTION
Hello, I am the maintainer of mecab-python3, unidic-lite, and other Japanese related packages. 

Your package uses my packages, but only when dealing with Japanese. My packages are unconditionally required by TTS. However, because my package involves a C++ extension, it is hard to build on M1 Macs. I also do not have the relevant hardware, and so I am unable to distribute wheels for that platform, for details see https://github.com/SamuraiT/mecab-python3/issues/84. 

For roughly a year (https://github.com/SamuraiT/mecab-python3/issues/71), people using TTS have intermittently bothered me about how to build things on OSX or other things I am unable to help with. I [explained how to fix this in December](https://github.com/coqui-ai/TTS/issues/2052#issuecomment-1348481112), but a member of your dev team seemed to consider it low priority, so I took it on myself to make this PR.

This change makes it so Japanese-related dependencies are not installed by default, but can be installed with `tts[ja]`, similar to the existing `tts[dev]`. If someone tries to use Japanese and the required packages are missing they will get an ImportError explaining the issue. This change will hopefully make it so people stop asking me for help with my software even though they don't need it in the first place.