### PR TITLE
Adds multi-language support for VITS onnx, fixes onnx exporting and inference errors

### DIFF
--- a/TTS/tts/models/vits.py
+++ b/TTS/tts/models/vits.py
@@ -1813,14 +1813,16 @@ class Vits(BaseTTS):
 
         # rollback values
         _forward = self.forward
-        disc = self.disc
+        disc = None
+        if hasattr(self, 'disc'):
+            disc = self.disc
         training = self.training
 
         # set export mode
         self.disc = None
         self.eval()
 
-        def onnx_inference(text, text_lengths, scales, sid=None):
+        def onnx_inference(text, text_lengths, scales, sid=None, langid=None):
             noise_scale = scales[0]
             length_scale = scales[1]
             noise_scale_dp = scales[2]
@@ -1833,7 +1835,7 @@ class Vits(BaseTTS):
                     "x_lengths": text_lengths,
                     "d_vectors": None,
                     "speaker_ids": sid,
-                    "language_ids": None,
+                    "language_ids": langid,
                     "durations": None,
                 },
             )["model_outputs"]
@@ -1844,11 +1846,14 @@ class Vits(BaseTTS):
         dummy_input_length = 100
         sequences = torch.randint(low=0, high=self.args.num_chars, size=(1, dummy_input_length), dtype=torch.long)
         sequence_lengths = torch.LongTensor([sequences.size(1)])
-        sepaker_id = None
+        speaker_id = None
+        language_id = None
         if self.num_speakers > 1:
-            sepaker_id = torch.LongTensor([0])
+            speaker_id = torch.LongTensor([0])
+        if self.num_languages > 0 and self.embedded_language_dim > 0:
+            language_id = torch.LongTensor([0])
         scales = torch.FloatTensor([self.inference_noise_scale, self.length_scale, self.inference_noise_scale_dp])
-        dummy_input = (sequences, sequence_lengths, scales, sepaker_id)
+        dummy_input = (sequences, sequence_lengths, scales, speaker_id, language_id)
 
         # export to ONNX
         torch.onnx.export(
@@ -1857,7 +1862,7 @@ class Vits(BaseTTS):
             opset_version=15,
             f=output_path,
             verbose=verbose,
-            input_names=["input", "input_lengths", "scales", "sid"],
+            input_names=["input", "input_lengths", "scales", "sid", "langid"],
             output_names=["output"],
             dynamic_axes={
                 "input": {0: "batch_size", 1: "phonemes"},
@@ -1870,7 +1875,8 @@ class Vits(BaseTTS):
         self.forward = _forward
         if training:
             self.train()
-        self.disc = disc
+        if not disc is None:
+            self.disc = disc
 
     def load_onnx(self, model_path: str, cuda=False):
         import onnxruntime as ort
@@ -1887,7 +1893,7 @@ class Vits(BaseTTS):
             providers=providers,
         )
 
-    def inference_onnx(self, x, x_lengths=None, speaker_id=None):
+    def inference_onnx(self, x, x_lengths=None, speaker_id=None, language_id=None):
         """ONNX inference"""
 
         if isinstance(x, torch.Tensor):
@@ -1902,13 +1908,15 @@ class Vits(BaseTTS):
             [self.inference_noise_scale, self.length_scale, self.inference_noise_scale_dp],
             dtype=np.float32,
         )
+		
         audio = self.onnx_sess.run(
             ["output"],
             {
                 "input": x,
                 "input_lengths": x_lengths,
                 "scales": scales,
-                "sid": torch.tensor([speaker_id]).cpu().numpy(),
+                "sid": None if speaker_id is None else torch.tensor([speaker_id]).cpu().numpy(),
+				"langid": None if language_id is None else torch.tensor([language_id]).cpu().numpy()
             },
         )
         return audio[0][0]


### PR DESCRIPTION
- Adds multi-language support for VITS onnx
- Fixes #2753 incorrect number of channels when having language_emb_dim > 0 
- Fixes onnx inference error when speaker_id is None or not passed as an argument
- Fixes onnx exporting error `AttributeError: 'Vits' object has no attribute 'disc'` for models with init_discriminator=false

Tested with multi-speaker and multi-language models, and with single speaker and single language, using the following script:

```
import torch
import os
import numpy as np
from TTS.tts.models.vits import Vits
from TTS.tts.configs.vits_config import VitsConfig
from TTS.utils.audio.numpy_transforms import save_wav

modelPath = "MULTILANG_MULTISPEAKER_PATH"
speaker_id = 0 '''None if no multi-speaker model'''
language_id = 0 '''None if no multi-language model'''

config = VitsConfig()
config.load_json(os.path.join(modelPath, "config.json"))
vits = Vits.init_from_config(config)

vits.load_onnx(os.path.join(modelPath, "MULTILANG_MULTISPEAKER_PATH.onnx"))

text = "LONG TEXT HERE"
text_inputs = np.asarray(
    vits.tokenizer.text_to_ids(text),
    dtype=np.int64,
)[None, :]

audio = vits.inference_onnx(text_inputs, speaker_id=speaker_id, language_id=language_id)
save_wav(wav=audio[0], path=os.path.join(os.path.dirname(__file__), 'test.wav'), sample_rate=config.audio.sample_rate)
```