### PR TITLE
Load the japanese phonemizer only if there's an environment variable set

### DIFF
--- a/.github/workflows/zoo_tests0.yml
+++ b/.github/workflows/zoo_tests0.yml
@@ -15,6 +15,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      ENABLE_JAPANESE: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zoo_tests1.yml
+++ b/.github/workflows/zoo_tests1.yml
@@ -15,6 +15,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      ENABLE_JAPANESE: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zoo_tests2.yml
+++ b/.github/workflows/zoo_tests2.yml
@@ -15,6 +15,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      ENABLE_JAPANESE: 1
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 .PHONY: test system-deps dev-deps deps style lint install help docs
 
-export ENABLE_JAPANESE := 1
+export ENABLE_JAPANESE = 1
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .DEFAULT_GOAL := help
 .PHONY: test system-deps dev-deps deps style lint install help docs
 
+export ENABLE_JAPANESE := 1
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,48 @@
 .DEFAULT_GOAL := help
 .PHONY: test system-deps dev-deps deps style lint install help docs
 
-export ENABLE_JAPANESE = 1
-
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 target_dirs := tests TTS notebooks recipes
 
 test_all:	## run tests and don't stop on an error.
-	nose2 --with-coverage --coverage TTS tests
-	./run_bash_tests.sh
+	ENABLE_JAPANESE=1 nose2 --with-coverage --coverage TTS tests
+	ENABLE_JAPANESE=1 ./run_bash_tests.sh
 
 test:	## run tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests
 
 test_vocoder:	## run vocoder tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.vocoder_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.vocoder_tests
 
 test_tts:	## run tts tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.tts_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.tts_tests
 
 test_tts2:	## run tts tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.tts_tests2
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.tts_tests2
 
 test_aux:	## run aux tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.aux_tests
-	./run_bash_tests.sh
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.aux_tests
+	ENABLE_JAPANESE=1 ./run_bash_tests.sh
 
 test_zoo:	## run zoo tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.zoo_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.zoo_tests
 
 inference_tests: ## run inference tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.inference_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.inference_tests
 
 api_tests: ## run api tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.api_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.api_tests
 
 data_tests: ## run data tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.data_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.data_tests
 
 test_text: ## run text tests.
-	nose2 -F -v -B --with-coverage --coverage TTS tests.text_tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests.text_tests
 
 test_failed:  ## only run tests failed the last time.
-	nose2 -F -v -B --with-coverage --coverage TTS tests
+	ENABLE_JAPANESE=1 nose2 -F -v -B --with-coverage --coverage TTS tests
 
 style:	## update code style.
 	black ${target_dirs}

--- a/TTS/tts/utils/text/phonemizers/__init__.py
+++ b/TTS/tts/utils/text/phonemizers/__init__.py
@@ -2,11 +2,20 @@ from TTS.tts.utils.text.phonemizers.bangla_phonemizer import BN_Phonemizer
 from TTS.tts.utils.text.phonemizers.base import BasePhonemizer
 from TTS.tts.utils.text.phonemizers.espeak_wrapper import ESpeak
 from TTS.tts.utils.text.phonemizers.gruut_wrapper import Gruut
-from TTS.tts.utils.text.phonemizers.ja_jp_phonemizer import JA_JP_Phonemizer
+import os
+if "ENABLE_JAPANESE" in os.environ:
+    JAPANESE_ENABLED = True
+    from TTS.tts.utils.text.phonemizers.ja_jp_phonemizer import JA_JP_Phonemizer
+else:
+    JAPANESE_ENABLED = False
+    print("Japanese disabled. Please create an environment variable named ENABLE_JAPANESE and install additional dependencies if you need to generate Japanese speech.")
 from TTS.tts.utils.text.phonemizers.ko_kr_phonemizer import KO_KR_Phonemizer
 from TTS.tts.utils.text.phonemizers.zh_cn_phonemizer import ZH_CN_Phonemizer
 
-PHONEMIZERS = {b.name(): b for b in (ESpeak, Gruut, JA_JP_Phonemizer)}
+phonemizer_classes = [ESpeak, Gruut]
+if JAPANESE_ENABLED:
+    phonemizer_classes.append(JA_JP_Phonemizer);
+PHONEMIZERS = {b.name(): b for b in phonemizer_classes}
 
 
 ESPEAK_LANGS = list(ESpeak.supported_languages().keys())
@@ -26,7 +35,8 @@ DEF_LANG_TO_PHONEMIZER.update(_new_dict)
 
 # Force default for some languages
 DEF_LANG_TO_PHONEMIZER["en"] = DEF_LANG_TO_PHONEMIZER["en-us"]
-DEF_LANG_TO_PHONEMIZER["ja-jp"] = JA_JP_Phonemizer.name()
+if JAPANESE_ENABLED:
+    DEF_LANG_TO_PHONEMIZER["ja-jp"] = JA_JP_Phonemizer.name()
 DEF_LANG_TO_PHONEMIZER["zh-cn"] = ZH_CN_Phonemizer.name()
 DEF_LANG_TO_PHONEMIZER["ko-kr"] = KO_KR_Phonemizer.name()
 DEF_LANG_TO_PHONEMIZER["bn"] = BN_Phonemizer.name()
@@ -48,7 +58,7 @@ def get_phonemizer_by_name(name: str, **kwargs) -> BasePhonemizer:
         return Gruut(**kwargs)
     if name == "zh_cn_phonemizer":
         return ZH_CN_Phonemizer(**kwargs)
-    if name == "ja_jp_phonemizer":
+    if name == "ja_jp_phonemizer" and JAPANESE_ENABLED:
         return JA_JP_Phonemizer(**kwargs)
     if name == "ko_kr_phonemizer":
         return KO_KR_Phonemizer(**kwargs)

--- a/TTS/tts/utils/text/phonemizers/__init__.py
+++ b/TTS/tts/utils/text/phonemizers/__init__.py
@@ -52,6 +52,7 @@ def get_phonemizer_by_name(name: str, **kwargs) -> BasePhonemizer:
         kwargs (dict):
             Extra keyword arguments that should be passed to the phonemizer.
     """
+    global JAPANESE_ENABLED
     if name == "espeak":
         return ESpeak(**kwargs)
     if name == "gruut":

--- a/TTS/tts/utils/text/phonemizers/__init__.py
+++ b/TTS/tts/utils/text/phonemizers/__init__.py
@@ -52,7 +52,6 @@ def get_phonemizer_by_name(name: str, **kwargs) -> BasePhonemizer:
         kwargs (dict):
             Extra keyword arguments that should be passed to the phonemizer.
     """
-    global JAPANESE_ENABLED
     if name == "espeak":
         return ESpeak(**kwargs)
     if name == "gruut":


### PR DESCRIPTION
After installing TTS using the following command
```bash
pip install TTS
```
this fails
```
from TTS.api import TTS
```

with the following error:
![Screenshot 2023-07-31 at 21-35-09 Google Colaboratory](https://github.com/coqui-ai/TTS/assets/42626106/a16dc7a6-1718-4378-ab82-c95a0b9cc483)

This fix expects the user to set an environment value to work with Japanese. The environment variable ENABLE_JAPANESE should exist for the ja_jp_phonemizer to be available.