### PR TITLE
add post functionality to /api/tts

### DIFF
--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -188,14 +188,15 @@ def details():
 lock = Lock()
 
 
-@app.route("/api/tts", methods=["GET"])
+@app.route("/api/tts", methods=["GET", "POST"])
 def tts():
     with lock:
-        text = request.args.get("text")
-        speaker_idx = request.args.get("speaker_id", "")
-        language_idx = request.args.get("language_id", "")
-        style_wav = request.args.get("style_wav", "")
+        text = request.headers.get('text') or request.values.get("text", "")
+        speaker_idx = request.headers.get('speaker-id') or request.values.get("speaker_id", "")
+        language_idx = request.headers.get('language-id') or request.values.get("language_id", "")
+        style_wav = request.headers.get('style-wav') or request.values.get("style_wav", "")
         style_wav = style_wav_uri_to_dict(style_wav)
+
         print(f" > Model input: {text}")
         print(f" > Speaker Idx: {speaker_idx}")
         print(f" > Language Idx: {language_idx}")


### PR DESCRIPTION
This PR add the ability to send POST requests to the /api/tts endpoint, it also adds the ability to utilize headers, with both GET and POST requests. It does not break any existing functionality.

```py
text = request.headers.get('text') or request.values.get("text", "")
```
I'm using `request.headers` to first check if the header exists, if true, the value is set. If false, fall back to URL encoding, utilizing `request.values` which works with both GET and POST requests.

I ran the following code to test each permutation
```py
import requests as re

url = 'http://ip:5002/api/tts'

print(re.get(f"{url}?text=Test GET&speaker_id=p225").status_code)
print(re.get(url, headers={'Text': 'Test GET', 'Speaker-Id':'p225'}).status_code)

print(re.post(f"{url}?text=Test POST&speaker_id=p225").status_code)
print(re.post(url, headers={'Text': 'Test POST', 'Speaker-Id':'p225'}).status_code)
```
Each requests returns a 200 status code, as well as a good wav file.

This was also confirmed in the server logs
```
INFO:werkzeug:::ffff:ip - - [04/Aug/2023 01:03:39] "GET /api/tts?text=Test%20GET&speaker_id=p225 HTTP/1.1" 200 -
INFO:werkzeug:::ffff:ip - - [04/Aug/2023 01:03:40] "GET /api/tts HTTP/1.1" 200 -
INFO:werkzeug:::ffff:ip - - [04/Aug/2023 01:03:40] "POST /api/tts?text=Test%20POST&speaker_id=p225 HTTP/1.1" 200 -
INFO:werkzeug:::ffff:ip - - [04/Aug/2023 01:03:40] "POST /api/tts HTTP/1.1" 200 -
```

Thanks
Chase