### PR TITLE
Denote human voices in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Please use our dedicated channels for questions and discussion. Help is much mor
 ## 🥇 TTS Performance
 <p align="center"><img src="https://raw.githubusercontent.com/coqui-ai/TTS/main/images/TTS-performance.png" width="800" /></p>
 
-Underlined "TTS*" and "Judy*" are **internal** 🐸TTS models that are not released open-source. They are here to show the potential.
+Underlined "TTS*" and "Judy*" are **internal** 🐸TTS models that are not released open-source. They are here to show the potential. Models prefixed with a dot (.Jofish .Abe and .Janice) are real human voices.
 
 ## Features
 - High-performance Deep Learning models for Text2Speech tasks.


### PR DESCRIPTION
It's unclear that some of the results in the TTS Performance section are not models; they are human voices.

See this issue: https://github.com/coqui-ai/TTS/issues/2706