### PR TITLE
Add device support in TTS and Synthesizer

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -1,8 +1,10 @@
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Union
 
 import numpy as np
+from torch import nn
 
 from TTS.cs_api import CS_API
 from TTS.utils.audio.numpy_transforms import save_wav
@@ -10,7 +12,7 @@ from TTS.utils.manage import ModelManager
 from TTS.utils.synthesizer import Synthesizer
 
 
-class TTS:
+class TTS(nn.Module):
     """TODO: Add voice conversion and Capacitron support."""
 
     def __init__(
@@ -62,6 +64,7 @@ class TTS:
                 Defaults to "XTTS".
             gpu (bool, optional): Enable/disable GPU. Some models might be too slow on CPU. Defaults to False.
         """
+        super().__init__()
         self.manager = ModelManager(models_file=self.get_models_file_path(), progress_bar=progress_bar, verbose=False)
 
         self.synthesizer = None
@@ -69,6 +72,9 @@ class TTS:
         self.csapi = None
         self.cs_api_model = cs_api_model
         self.model_name = None
+
+        if gpu:
+            warnings.warn("`gpu` will be deprecated. Please use `tts.to(device)` instead.")
 
         if model_name is not None:
             if "tts_models" in model_name or "coqui_studio" in model_name:

--- a/TTS/tts/utils/synthesis.py
+++ b/TTS/tts/utils/synthesis.py
@@ -5,19 +5,17 @@ import torch
 from torch import nn
 
 
-def numpy_to_torch(np_array, dtype, cuda=False):
+def numpy_to_torch(np_array, dtype, device="cpu"):
     if np_array is None:
         return None
-    tensor = torch.as_tensor(np_array, dtype=dtype)
-    if cuda:
-        return tensor.cuda()
+    tensor = torch.as_tensor(np_array, dtype=dtype, device=device)
     return tensor
 
 
-def compute_style_mel(style_wav, ap, cuda=False):
-    style_mel = torch.FloatTensor(ap.melspectrogram(ap.load_wav(style_wav, sr=ap.sample_rate))).unsqueeze(0)
-    if cuda:
-        return style_mel.cuda()
+def compute_style_mel(style_wav, ap, device="cpu"):
+    style_mel = torch.FloatTensor(
+        ap.melspectrogram(ap.load_wav(style_wav, sr=ap.sample_rate)), device=device,
+    ).unsqueeze(0)
     return style_mel
 
 
@@ -73,22 +71,18 @@ def inv_spectrogram(postnet_output, ap, CONFIG):
     return wav
 
 
-def id_to_torch(aux_id, cuda=False):
+def id_to_torch(aux_id, device="cpu"):
     if aux_id is not None:
         aux_id = np.asarray(aux_id)
-        aux_id = torch.from_numpy(aux_id)
-    if cuda:
-        return aux_id.cuda()
+        aux_id = torch.from_numpy(aux_id).to(device)
     return aux_id
 
 
-def embedding_to_torch(d_vector, cuda=False):
+def embedding_to_torch(d_vector, device="cpu"):
     if d_vector is not None:
         d_vector = np.asarray(d_vector)
         d_vector = torch.from_numpy(d_vector).type(torch.FloatTensor)
-        d_vector = d_vector.squeeze().unsqueeze(0)
-    if cuda:
-        return d_vector.cuda()
+        d_vector = d_vector.squeeze().unsqueeze(0).to(device)
     return d_vector
 
 
@@ -162,6 +156,9 @@ def synthesis(
         language_id (int):
             Language ID passed to the language embedding layer in multi-langual model. Defaults to None.
     """
+    # device
+    device = next(model.parameters()).device
+
     # GST or Capacitron processing
     # TODO: need to handle the case of setting both gst and capacitron to true somewhere
     style_mel = None
@@ -169,10 +166,10 @@ def synthesis(
         if isinstance(style_wav, dict):
             style_mel = style_wav
         else:
-            style_mel = compute_style_mel(style_wav, model.ap, cuda=use_cuda)
+            style_mel = compute_style_mel(style_wav, model.ap, device=device)
 
     if CONFIG.has("capacitron_vae") and CONFIG.use_capacitron_vae and style_wav is not None:
-        style_mel = compute_style_mel(style_wav, model.ap, cuda=use_cuda)
+        style_mel = compute_style_mel(style_wav, model.ap, device=device)
         style_mel = style_mel.transpose(1, 2)  # [1, time, depth]
 
     language_name = None
@@ -188,26 +185,26 @@ def synthesis(
     )
     # pass tensors to backend
     if speaker_id is not None:
-        speaker_id = id_to_torch(speaker_id, cuda=use_cuda)
+        speaker_id = id_to_torch(speaker_id, device=device)
 
     if d_vector is not None:
-        d_vector = embedding_to_torch(d_vector, cuda=use_cuda)
+        d_vector = embedding_to_torch(d_vector, device=device)
 
     if language_id is not None:
-        language_id = id_to_torch(language_id, cuda=use_cuda)
+        language_id = id_to_torch(language_id, device=device)
 
     if not isinstance(style_mel, dict):
         # GST or Capacitron style mel
-        style_mel = numpy_to_torch(style_mel, torch.float, cuda=use_cuda)
+        style_mel = numpy_to_torch(style_mel, torch.float, device=device)
         if style_text is not None:
             style_text = np.asarray(
                 model.tokenizer.text_to_ids(style_text, language=language_id),
                 dtype=np.int32,
             )
-            style_text = numpy_to_torch(style_text, torch.long, cuda=use_cuda)
+            style_text = numpy_to_torch(style_text, torch.long, device=device)
             style_text = style_text.unsqueeze(0)
 
-    text_inputs = numpy_to_torch(text_inputs, torch.long, cuda=use_cuda)
+    text_inputs = numpy_to_torch(text_inputs, torch.long, device=device)
     text_inputs = text_inputs.unsqueeze(0)
     # synthesize voice
     outputs = run_model_torch(

--- a/TTS/tts/utils/synthesis.py
+++ b/TTS/tts/utils/synthesis.py
@@ -5,14 +5,18 @@ import torch
 from torch import nn
 
 
-def numpy_to_torch(np_array, dtype, device="cpu"):
+def numpy_to_torch(np_array, dtype, cuda=False, device="cpu"):
+    if cuda:
+        device = "cuda"
     if np_array is None:
         return None
     tensor = torch.as_tensor(np_array, dtype=dtype, device=device)
     return tensor
 
 
-def compute_style_mel(style_wav, ap, device="cpu"):
+def compute_style_mel(style_wav, ap, cuda=False, device="cpu"):
+    if cuda:
+        device = "cuda"
     style_mel = torch.FloatTensor(
         ap.melspectrogram(ap.load_wav(style_wav, sr=ap.sample_rate)), device=device,
     ).unsqueeze(0)
@@ -71,14 +75,18 @@ def inv_spectrogram(postnet_output, ap, CONFIG):
     return wav
 
 
-def id_to_torch(aux_id, device="cpu"):
+def id_to_torch(aux_id, cuda=False, device="cpu"):
+    if cuda:
+        device = "cuda"
     if aux_id is not None:
         aux_id = np.asarray(aux_id)
         aux_id = torch.from_numpy(aux_id).to(device)
     return aux_id
 
 
-def embedding_to_torch(d_vector, device="cpu"):
+def embedding_to_torch(d_vector, cuda=False, device="cpu"):
+    if cuda:
+        device = "cuda"
     if d_vector is not None:
         d_vector = np.asarray(d_vector)
         d_vector = torch.from_numpy(d_vector).type(torch.FloatTensor)

--- a/TTS/tts/utils/synthesis.py
+++ b/TTS/tts/utils/synthesis.py
@@ -166,6 +166,8 @@ def synthesis(
     """
     # device
     device = next(model.parameters()).device
+    if use_cuda:
+        device = "cuda"
 
     # GST or Capacitron processing
     # TODO: need to handle the case of setting both gst and capacitron to true somewhere
@@ -295,22 +297,27 @@ def transfer_voice(
         do_trim_silence (bool):
             trim silence after synthesis. Defaults to False.
     """
+    # device
+    device = next(model.parameters()).device
+    if use_cuda:
+        device = "cuda"
+
     # pass tensors to backend
     if speaker_id is not None:
-        speaker_id = id_to_torch(speaker_id, cuda=use_cuda)
+        speaker_id = id_to_torch(speaker_id, device=device)
 
     if d_vector is not None:
-        d_vector = embedding_to_torch(d_vector, cuda=use_cuda)
+        d_vector = embedding_to_torch(d_vector, device=device)
 
     if reference_d_vector is not None:
-        reference_d_vector = embedding_to_torch(reference_d_vector, cuda=use_cuda)
+        reference_d_vector = embedding_to_torch(reference_d_vector, device=device)
 
     # load reference_wav audio
     reference_wav = embedding_to_torch(
         model.ap.load_wav(
             reference_wav, sr=model.args.encoder_sample_rate if model.args.encoder_sample_rate else model.ap.sample_rate
         ),
-        cuda=use_cuda,
+        device=device,
     )
 
     if hasattr(model, "module"):

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -408,8 +408,7 @@ class Synthesizer(nn.Module):
                     # run vocoder model
                     # [1, T, C]
                     waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-                if self.use_cuda and not use_gl:
-                    waveform = waveform.cpu()
+                waveform = waveform.cpu()
                 if not use_gl:
                     waveform = waveform.numpy()
                 waveform = waveform.squeeze()

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -410,7 +410,7 @@ class Synthesizer(nn.Module):
                     # run vocoder model
                     # [1, T, C]
                     waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-                if not use_gl and waveform.device != torch.device("cpu"):
+                if waveform.device != torch.device("cpu") and not use_gl:
                     waveform = waveform.cpu()
                 if not use_gl:
                     waveform = waveform.numpy()
@@ -474,7 +474,7 @@ class Synthesizer(nn.Module):
                 # run vocoder model
                 # [1, T, C]
                 waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-            if not use_gl and waveform.device != torch.device("cpu"):
+            if waveform.device != torch.device("cpu"):
                     waveform = waveform.cpu()
             if not use_gl:
                 waveform = waveform.numpy()

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -5,6 +5,7 @@ from typing import List
 import numpy as np
 import pysbd
 import torch
+from torch import nn
 
 from TTS.config import load_config
 from TTS.tts.configs.vits_config import VitsConfig
@@ -21,7 +22,7 @@ from TTS.vocoder.models import setup_model as setup_vocoder_model
 from TTS.vocoder.utils.generic_utils import interpolate_vocoder_input
 
 
-class Synthesizer(object):
+class Synthesizer(nn.Module):
     def __init__(
         self,
         tts_checkpoint: str = "",
@@ -60,6 +61,7 @@ class Synthesizer(object):
             vc_config (str, optional): path to the voice conversion config file. Defaults to `""`,
             use_cuda (bool, optional): enable/disable cuda. Defaults to False.
         """
+        super().__init__()
         self.tts_checkpoint = tts_checkpoint
         self.tts_config_path = tts_config_path
         self.tts_speakers_file = tts_speakers_file

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -475,7 +475,7 @@ class Synthesizer(nn.Module):
                 # [1, T, C]
                 waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
             if waveform.device != torch.device("cpu"):
-                    waveform = waveform.cpu()
+                waveform = waveform.cpu()
             if not use_gl:
                 waveform = waveform.numpy()
             wavs = waveform.squeeze()

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -362,6 +362,8 @@ class Synthesizer(nn.Module):
         use_gl = self.vocoder_model is None
         if not use_gl:
             vocoder_device = next(self.vocoder_model.parameters()).device
+        if self.use_cuda:
+            vocoder_device = "cuda"
 
         if not reference_wav:  # not voice conversion
             for sen in sens:
@@ -408,7 +410,8 @@ class Synthesizer(nn.Module):
                     # run vocoder model
                     # [1, T, C]
                     waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-                waveform = waveform.cpu()
+                if not use_gl and waveform.device != torch.device("cpu"):
+                    waveform = waveform.cpu()
                 if not use_gl:
                     waveform = waveform.numpy()
                 waveform = waveform.squeeze()
@@ -471,7 +474,8 @@ class Synthesizer(nn.Module):
                 # run vocoder model
                 # [1, T, C]
                 waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-            waveform = waveform.cpu()
+            if not use_gl and waveform.device != torch.device("cpu"):
+                    waveform = waveform.cpu()
             if not use_gl:
                 waveform = waveform.numpy()
             wavs = waveform.squeeze()

--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -410,7 +410,7 @@ class Synthesizer(nn.Module):
                     # run vocoder model
                     # [1, T, C]
                     waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-                if waveform.device != torch.device("cpu") and not use_gl:
+                if torch.is_tensor(waveform) and waveform.device != torch.device("cpu") and not use_gl:
                     waveform = waveform.cpu()
                 if not use_gl:
                     waveform = waveform.numpy()
@@ -474,7 +474,7 @@ class Synthesizer(nn.Module):
                 # run vocoder model
                 # [1, T, C]
                 waveform = self.vocoder_model.inference(vocoder_input.to(vocoder_device))
-            if waveform.device != torch.device("cpu"):
+            if torch.is_tensor(waveform) and waveform.device != torch.device("cpu"):
                 waveform = waveform.cpu()
             if not use_gl:
                 waveform = waveform.numpy()


### PR DESCRIPTION
## Context

In https://github.com/coqui-ai/TTS/issues/2282, we proposed up the possibility of implementing a`tts.to(device)` interface as a substitute for `use_cuda` or `gpu` flags. The current flags do not allow users to specify the specific GPU device (e.g., `cuda:3`). It also does not allow users to use other accelerated backends, such as Apple Silicon GPUs ([MPS](https://pytorch.org/docs/stable/notes/mps.html)), which PyTorch now supports.

## Solution

We make `TTS` and `Synthesizer` classes inherit from `nn.Module`. This gives us `.to(device)` for free for both of the classes. 

We can now run TTS on Apple Silicon (tested on M2 Max). Not all kernels have been implemented in MPS in PyTorch yet, so we need to set the environment variable

```
export PYTORCH_ENABLE_MPS_FALLBACK=1
``` 

to enable CPU fallback. With this set, we can now run

```python
>>> from TTS.api import TTS
>>> model_name = TTS.list_models()[0]
>>> tts = TTS(model_name)
>>> tts = tts.to("mps")
>>> tts.tts_to_file(text="Hello world!", speaker=tts.speakers[0], language=tts.languages[0], file_path="output.wav")
```

Also tested with `make test`.