### PR TITLE
Add customizable data home path

### DIFF
--- a/TTS/utils/generic_utils.py
+++ b/TTS/utils/generic_utils.py
@@ -126,7 +126,10 @@ def get_import_path(obj: object) -> str:
 
 
 def get_user_data_dir(appname):
-    if sys.platform == "win32":
+    XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME")
+    if XDG_DATA_HOME is not None:
+        ans = Path(XDG_DATA_HOME).expanduser().resolve(strict=False)
+    elif sys.platform == "win32":
         import winreg  # pylint: disable=import-outside-toplevel
 
         key = winreg.OpenKey(

--- a/TTS/utils/generic_utils.py
+++ b/TTS/utils/generic_utils.py
@@ -126,8 +126,11 @@ def get_import_path(obj: object) -> str:
 
 
 def get_user_data_dir(appname):
+    TTS_HOME = os.environ.get("TTS_HOME")
     XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME")
-    if XDG_DATA_HOME is not None:
+    if TTS_HOME is not None:
+        ans = Path(TTS_HOME).expanduser().resolve(strict=False)
+    elif XDG_DATA_HOME is not None:
         ans = Path(XDG_DATA_HOME).expanduser().resolve(strict=False)
     elif sys.platform == "win32":
         import winreg  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
`export XDG_DATA_HOME="/path/to/download"` or `export TTS_HOME="/path/to/download"` will now allow for changing the download path of the models.

Solves https://github.com/coqui-ai/TTS/issues/2680 with @reuben's suggestion.

