### PR TITLE
Add device flag to TTS CLI

### DIFF
--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -169,6 +169,7 @@ If you don't specify any models, then it uses LJSpeech based English model.
         help="Output wav file path.",
     )
     parser.add_argument("--use_cuda", type=bool, help="Run model on CUDA.", default=False)
+    parser.add_argument("--device", type=str, help="Device to run model on.", default="cpu")
     parser.add_argument(
         "--vocoder_path",
         type=str,
@@ -391,6 +392,10 @@ If you don't specify any models, then it uses LJSpeech based English model.
     if args.encoder_path is not None:
         encoder_path = args.encoder_path
         encoder_config_path = args.encoder_config_path
+    
+    device = args.device
+    if args.use_cuda:
+        device = "cuda"
 
     # load models
     synthesizer = Synthesizer(
@@ -406,8 +411,7 @@ If you don't specify any models, then it uses LJSpeech based English model.
         vc_config_path,
         model_dir,
         args.voice_dir,
-        args.use_cuda,
-    )
+    ).to(device)
 
     # query speaker ids of a multi-speaker model.
     if args.list_speaker_idxs:


### PR DESCRIPTION
## Context

In https://github.com/coqui-ai/TTS/pull/2855, we added a new `.to(device)` API for the TTS class, allowing users to freely choose the accelerator backend of their choice. For further ease of access, we want to incorporate this new feature into the TTS CLI, which currently only allows users to specify the device via `--use_cuda`. 

## Solution

Add a new `--device` flag to the TTS CLI. Now, uses can do

```
$ tts --text "hello world" --device cuda:1  # specify cuda device
$ tts --text "hello world" --device maps  # use apple silicon
```

