### PR TITLE
Update README with new device API

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ More details about the docker images (like GPU support) can be found [here](http
 
 ### 🐍 Python API
 
+#### Running a multi-speaker and multi-lingual model
+
 ```python
 import torch
 from TTS.api import TTS
-
-# Running a multi-speaker and multi-lingual model
 
 # Get device
 device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/README.md
+++ b/README.md
@@ -213,13 +213,13 @@ tts.tts_to_file(text="Hello world!", speaker=tts.speakers[0], language=tts.langu
 
 ```python
 # Init TTS with the target model name
-tts = TTS(model_name="tts_models/de/thorsten/tacotron2-DDC", progress_bar=False).to("cuda")
+tts = TTS(model_name="tts_models/de/thorsten/tacotron2-DDC", progress_bar=False).to(device)
 
 # Run TTS
 tts.tts_to_file(text="Ich bin eine Testnachricht.", file_path=OUTPUT_PATH)
 
 # Example voice cloning with YourTTS in English, French and Portuguese
-tts = TTS(model_name="tts_models/multilingual/multi-dataset/your_tts", progress_bar=False).to("cuda")
+tts = TTS(model_name="tts_models/multilingual/multi-dataset/your_tts", progress_bar=False).to(device)
 tts.tts_to_file("This is voice cloning.", speaker_wav="my/cloning/audio.wav", language="en", file_path="output.wav")
 tts.tts_to_file("C'est le clonage de la voix.", speaker_wav="my/cloning/audio.wav", language="fr-fr", file_path="output.wav")
 tts.tts_to_file("Isso é clonagem de voz.", speaker_wav="my/cloning/audio.wav", language="pt-br", file_path="output.wav")

--- a/README.md
+++ b/README.md
@@ -188,17 +188,20 @@ More details about the docker images (like GPU support) can be found [here](http
 ### 🐍 Python API
 
 ```python
+import torch
 from TTS.api import TTS
 
 # Running a multi-speaker and multi-lingual model
 
+# Get device
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 # List available 🐸TTS models and choose the first one
 model_name = TTS().list_models()[0]
 # Init TTS
-tts = TTS(model_name)
+tts = TTS(model_name).to(device)
 
 # Run TTS
-
 # ❗ Since this model is multi-speaker and multi-lingual, we must set the target speaker and the language
 # Text to speech with a numpy output
 wav = tts.tts("This is a test! This is also a test!!", speaker=tts.speakers[0], language=tts.languages[0])

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ from TTS.api import TTS
 # Running a multi-speaker and multi-lingual model
 
 # List available 🐸TTS models and choose the first one
-model_name = TTS.list_models()[0]
+model_name = TTS().list_models()[0]
 # Init TTS
 tts = TTS(model_name)
 
@@ -210,13 +210,13 @@ tts.tts_to_file(text="Hello world!", speaker=tts.speakers[0], language=tts.langu
 
 ```python
 # Init TTS with the target model name
-tts = TTS(model_name="tts_models/de/thorsten/tacotron2-DDC", progress_bar=False, gpu=False)
+tts = TTS(model_name="tts_models/de/thorsten/tacotron2-DDC", progress_bar=False).to("cuda")
+
 # Run TTS
 tts.tts_to_file(text="Ich bin eine Testnachricht.", file_path=OUTPUT_PATH)
 
 # Example voice cloning with YourTTS in English, French and Portuguese
-
-tts = TTS(model_name="tts_models/multilingual/multi-dataset/your_tts", progress_bar=False, gpu=True)
+tts = TTS(model_name="tts_models/multilingual/multi-dataset/your_tts", progress_bar=False).to("cuda")
 tts.tts_to_file("This is voice cloning.", speaker_wav="my/cloning/audio.wav", language="en", file_path="output.wav")
 tts.tts_to_file("C'est le clonage de la voix.", speaker_wav="my/cloning/audio.wav", language="fr-fr", file_path="output.wav")
 tts.tts_to_file("Isso é clonagem de voz.", speaker_wav="my/cloning/audio.wav", language="pt-br", file_path="output.wav")
@@ -227,7 +227,7 @@ tts.tts_to_file("Isso é clonagem de voz.", speaker_wav="my/cloning/audio.wav", 
 Converting the voice in `source_wav` to the voice of `target_wav`
 
 ```python
-tts = TTS(model_name="voice_conversion_models/multilingual/vctk/freevc24", progress_bar=False, gpu=True)
+tts = TTS(model_name="voice_conversion_models/multilingual/vctk/freevc24", progress_bar=False).to("cuda")
 tts.voice_conversion_to_file(source_wav="my/source.wav", target_wav="my/target.wav", file_path="output.wav")
 ```
 
@@ -256,7 +256,7 @@ These models will follow the naming convention `coqui_studio/en/<studio_speaker_
 # XTTS model
 models = TTS(cs_api_model="XTTS").list_models()
 # Init TTS with the target studio speaker
-tts = TTS(model_name="coqui_studio/en/Torcull Diarmuid/coqui_studio", progress_bar=False, gpu=False)
+tts = TTS(model_name="coqui_studio/en/Torcull Diarmuid/coqui_studio", progress_bar=False)
 # Run TTS
 tts.tts_to_file(text="This is a test.", file_path=OUTPUT_PATH)
 


### PR DESCRIPTION
## Context

In https://github.com/coqui-ai/TTS/pull/2855, we added a new `.to(device)` API for the TTS class, allowing users to freely choose the accelerator backend of their choice. We need to update the README with this information.

## Solution

Remove examples that use the `gpu` flag and use `to(device)` instead.