### PR TITLE
Fixed spectrogram checking on librosa 0.10.x

### DIFF
--- a/notebooks/dataset_analysis/CheckSpectrograms.ipynb
+++ b/notebooks/dataset_analysis/CheckSpectrograms.ipynb
@@ -254,8 +254,8 @@
     "        wav_gen = AP.inv_spectrogram(spec)\n",
     "        wavs.append(wav_gen)\n",
     "        plt.subplot(len(values), 2, 2*idx + 2)\n",
-    "        display.waveplot(wav, alpha=0.5)\n",
-    "        display.waveplot(wav_gen, alpha=0.25)\n",
+    "        display.waveshow(wav, alpha=0.5)\n",
+    "        display.waveshow(wav_gen, alpha=0.25)\n",
     "        plt.title(\"{}={}\".format(attribute, val))\n",
     "        plt.tight_layout()\n",
     "    \n",
@@ -288,7 +288,7 @@
    },
    "outputs": [],
    "source": [
-    "compare_values(\"ref_level_db\", [2, 5, 10, 15, 20, 25, 30, 35, 40, 1000])"
+    "compare_values(\"ref_level_db\", [2, 5, 10, 15, 20, 25, 30, 35, 40])"
    ]
   }
  ],


### PR DESCRIPTION
The `waveplot` function from 0.8 seems to have been consolidated into `waveshow` in 0.10.