### PR TITLE
Fix requests exception handling in manage.py

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -325,7 +325,7 @@ class ModelManager(object):
                 elif "hf_url" in model_item:
                     self._download_hf_model(model_item, output_path)
 
-            except requests.Exception.RequestException as e:
+            except requests.RequestException as e:
                 print(f" > Failed to download the model file to {output_path}")
                 rmtree(output_path)
                 raise e


### PR DESCRIPTION
module 'requests' has no attribute 'Exception' appears when the model download fails (when the domain is blocked, for example).

This PR corrects the exception reference according to: https://requests.readthedocs.io/en/latest/api/#requests.RequestException