### PR TITLE
Updated scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy==1.22.0;python_version<="3.10"
 numpy==1.24.3;python_version>"3.10"
 cython==0.29.30
-scipy>=1.4.0
+scipy>=1.11.2
 torch>=1.7
 torchaudio
 soundfile


### PR DESCRIPTION
Old scipy version causes an error '_`orrtl: error (200): program aborting due to control-C event`_' when cancelling download function with Ctrl+C, that cannot be handled by try/except block correctly. Because of this, cleanup doesn't work on unsuccessful model download and an error occurs at the next start, because directory already exists. This behavior has been corrected in the new version.