### PR TITLE
Fix a division by zero error, happens quite often during multilingual automated inference 

### DIFF
--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -484,5 +484,5 @@ class Synthesizer(nn.Module):
         process_time = time.time() - start_time
         audio_time = len(wavs) / self.tts_config.audio["sample_rate"]
         print(f" > Processing time: {process_time}")
-        print(f" > Real-time factor: {process_time / audio_time}")
+        print(f" > Real-time factor: {process_time / audio_time if audio_time != 0 else 'undefined'}")
         return wavs


### PR DESCRIPTION
fix an annoying bug (minor), happens quite often when running coquiTTS automatically
`        print(f" > Real-time factor: {process_time / audio_time}")`
to
`        print(f" > Real-time factor: {process_time / audio_time if audio_time != 0 else 'undefined'}")`
It will happen whenever the sentence split function produce empty string, or empty string is entered by accident, which cause audio_time=0