### PR TITLE
pass self.device to load_fsspec function

### DIFF
--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -642,7 +642,7 @@ class Xtts(BaseTTS):
         self.init_models()
         if eval:
             self.gpt.init_gpt_for_inference(kv_cache=self.args.kv_cache)
-        self.load_state_dict(load_fsspec(model_path)["model"], strict=strict)
+        self.load_state_dict(load_fsspec(model_path, map_location=self.device)["model"], strict=strict)
 
         if eval:
             self.gpt.init_gpt_for_inference(kv_cache=self.args.kv_cache)


### PR DESCRIPTION
In case using cuda by default, pass self.device to choose the right device user defined in to() function.