### PR TITLE
Loosen dependency pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython==0.29.30", "numpy==1.22.0", "packaging"]
+requires = [
+    "setuptools",
+    "wheel",
+    "cython~=0.29.30",
+    "numpy>=1.22.0",
+    "packaging",
+]
 
 [flake8]
 max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ flask==2.*
 pysbd==0.3.4
 # deps for notebooks
 umap-learn==0.5.*
-pandas==1.4.*
+pandas>=1.4,<2.0
 # deps for training
 matplotlib==3.7.*
 # coqui stack


### PR DESCRIPTION
Follows up on https://github.com/coqui-ai/TTS/pull/2990.

Turns out the pinned dependencies cause e.g. my Mac to try and start building Numpy and Pandas from source.

ping @WeberJulian 