### PR TITLE
fixed typo of /docs

### DIFF
--- a/docs/source/main_classes/trainer_api.md
+++ b/docs/source/main_classes/trainer_api.md
@@ -1,3 +1,3 @@
 # Trainer API
 
-We made the trainer a seprate project on https://github.com/coqui-ai/Trainer
+We made the trainer a separate project on https://github.com/coqui-ai/Trainer

--- a/docs/source/models/forward_tts.md
+++ b/docs/source/models/forward_tts.md
@@ -12,7 +12,7 @@ Currently we provide the following pre-configured architectures:
 
 - **FastPitch:**
 
-    It uses the same FastSpeech architecture that is conditioned on fundemental frequency (f0) contours with the
+    It uses the same FastSpeech architecture that is conditioned on fundamental frequency (f0) contours with the
     promise of more expressive speech.
 
 - **SpeedySpeech:**


### PR DESCRIPTION
fixed typo of "docs/source/main_classes/trainer_api.md" and "docs/source/models/forward_tts.md"
fundemental -> fundamental 
seprate -> separate 