### PR TITLE
fix cache config error

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -346,7 +346,10 @@ class ModelManager(object):
 
     def check_if_configs_are_equal(self, model_name, model_item, output_path):
         with fsspec.open(self._find_files(output_path)[1], "r", encoding="utf-8") as f:
-            config_local = json.load(f)
+            try:
+                config_local = json.load(f)
+            except:
+                config_local = None
         remote_url = None
         for url in model_item["hf_url"]:
             if "config.json" in url:


### PR DESCRIPTION
# What does this fix?

Fixes this problem: https://github.com/coqui-ai/TTS/issues/3074

# What was the problem?

When the TTS library fails to download the config files for some reason (which has been happening very often recently), we end up with `config.json`, `model.pth`, `vocab.json` files that are empty (0 bytes).

When this happens, the `json.load(f)` line fails and it doesn't even reach the next line where it compares `config_local` with `config_remote`.

This is made worse by the exception handler at https://github.com/cocktailpeanut/TTS/blob/33c95daa55808817b67e5bf66c68134889059c15/TTS/utils/manage.py#L402 NOT handling the error and calling `pass`.

To fix this, I've added the `try/except` clause, and if the try fails it sets the`config_local` to None and at least moves to the next line and compares with `config_remote`, at which point it should correctly recognize that they are different and retry the download.
