### PR TITLE
XTTS- Torchaudio should use proper backend to load audio

### DIFF
--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -69,12 +69,9 @@ def wav_to_mel_cloning(
 
 def load_audio(audiopath, sampling_rate):
     # better load setting following: https://github.com/faroit/python_audio_loading_benchmark
-    if audiopath[-4:] == ".mp3":
-        # it uses torchaudio with sox backend to load mp3
-        audio, lsr = torchaudio.backend.sox_io_backend.load(audiopath)
-    else:
-        # it uses torchaudio soundfile backend to load all the others data type
-        audio, lsr = torchaudio.backend.soundfile_backend.load(audiopath)
+
+    # torchaudio should chose proper backend to load audio depending on platform
+    audio, lsr = torchaudio.load(audiopath)
 
     # stereo to mono if needed
     if audio.size(0) != 1:


### PR DESCRIPTION
Depending on platform and installed libraries, delegate audio loading to torchaudio.

torchaudio<2.1 backend can be selected globally after torchaudio>2.1 backend has changes and ordered backends are used.
Also soundfile>=0.12 made breaking changes and uses now libsndfile packages not platform installed libraries. 

This is one of the reasons with problems on mp3 and mp4 files

With this change for getting latents:

* we can override torchaudio backend (until 2.0.1 at least)
* Windows users can use mp3 files on loading latest (soundfile>0.11 has support for it and as sox backend is not available by default on windows)
* can use sox to Load mp4 files on linux
* can use audiofiles without suffix (as binary file-like objects), which sox/ffmpeg can handle 