### PR TITLE
Ensures that only GPT model is in training mode during XTTS GPT training

### DIFF
--- a/TTS/tts/layers/xtts/trainer/gpt_trainer.py
+++ b/TTS/tts/layers/xtts/trainer/gpt_trainer.py
@@ -318,9 +318,10 @@ class GPTTrainer(BaseTTS):
         batch["cond_idxs"] = None
         return self.train_step(batch, criterion)
 
-    def on_epoch_start(self, trainer):  # pylint: disable=W0613
-        # guarante that dvae will be in eval mode after .train() on evaluation end
-        self.dvae = self.dvae.eval()
+    def on_train_epoch_start(self, trainer):
+        trainer.model.eval() # the whole model to eval
+        # put gpt model in training mode
+        trainer.model.xtts.gpt.train()
 
     def on_init_end(self, trainer):  # pylint: disable=W0613
         # ignore similarities.pth on clearml save/upload

--- a/TTS/vocoder/configs/parallel_wavegan_config.py
+++ b/TTS/vocoder/configs/parallel_wavegan_config.py
@@ -94,6 +94,7 @@ class ParallelWaveganConfig(BaseGANVocoderConfig):
     use_noise_augment: bool = False
     use_cache: bool = True
     steps_to_start_discriminator: int = 200000
+    target_loss: str = "loss_1"
 
     # LOSS PARAMETERS - overrides
     use_stft_loss: bool = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pandas>=1.4,<2.0
 # deps for training
 matplotlib==3.7.*
 # coqui stack
-trainer
+trainer>=0.0.32
 # config management
 coqpit>=0.0.16
 # chinese g2p deps


### PR DESCRIPTION
Currently,  during GPT XTTS training the DVAE are not in eval mode. This PR fixes it using the new on_train_epoch_start callback from the latest trainer version.

It also fix a issue with parallel wavegan unit test. The target_loss "loss_0" that is the default from GAN vocoder training do not exist for parallel wavegan  and it raises an error with the latest trainer version. 