### PR TITLE
More informative error for wrong --language argument

### DIFF
--- a/TTS/bin/synthesize.py
+++ b/TTS/bin/synthesize.py
@@ -419,6 +419,13 @@ def main():
             print(" > Saving output to ", args.out_path)
             return
 
+        if args.language_idx is None and args.language is not None:
+            msg = (
+                "--language is only supported for Coqui Studio models. "
+                "Use --language_idx to specify the target language for multilingual models."
+            )
+            raise ValueError(msg)
+
         # CASE4: load pre-trained model paths
         if args.model_name is not None and not args.model_path:
             model_path, config_path, model_item = manager.download_model(args.model_name)


### PR DESCRIPTION
In multilingual models, the target language is specified via the `--language_idx` argument. However, the `tts` CLI also accepts a `--language` argument for use with Coqui Studio, so it is easy to choose the wrong one, resulting in the following confusing error at synthesis time:

```
AssertionError:  ❗ Language None is not supported. Supported languages are
['en', 'es', 'fr', 'de', 'it', 'pt', 'pl', 'tr', 'ru', 'nl', 'cs', 'ar',
'zh-cn', 'hu', 'ko', 'ja']
```

This commit adds a better error message when `--language` is passed for a non-studio model.

Fixes #3270, fixes #3291