### PR TITLE
fix pause problem of Chinese speech

### DIFF
--- a/TTS/tts/layers/xtts/zh_num2words.py
+++ b/TTS/tts/layers/xtts/zh_num2words.py
@@ -65,7 +65,7 @@ CN_PUNCS_NONSTOP = "＂＃＄％＆＇（）＊＋，－／：；＜＝＞＠［
 CN_PUNCS = CN_PUNCS_STOP + CN_PUNCS_NONSTOP
 
 PUNCS = CN_PUNCS + string.punctuation
-PUNCS_TRANSFORM = str.maketrans(PUNCS, " " * len(PUNCS), "")  # replace puncs with space
+PUNCS_TRANSFORM = str.maketrans(PUNCS, "," * len(PUNCS), "")  # replace puncs with English comma
 
 
 # https://zh.wikipedia.org/wiki/全行和半行


### PR DESCRIPTION
The pauses in Chinese speech generated by xtts pretrained model are somewhat unnatural.  And I found that punctuation in Chinese text  were replaced with spaces. I replaced punctuation with English comma, and it performs better.

Here's an example:

space

https://github.com/coqui-ai/TTS/assets/44492123/02d8ceb7-8c2c-4b26-9862-e538f97c5c6f

English comma

https://github.com/coqui-ai/TTS/assets/44492123/0be880eb-13ca-4e12-aed2-40e9d77b3a35

Here's the text:
`> Using model: xtts
 > Text splitted to sentences.
['在汉字文化圈和海外华人社区中，中文也被称为汉文、华文。', '汉字主要起源于记事的象形性图画，象形字是汉字体系得以形成和发展的基础。', '后来的演变经历
了几千年的漫长历程，经历了甲骨文、金文、篆书、隶书、楷书、草书、行书等阶段，普遍使用楷书。']
 > Processing time: 53.86410617828369
 > Real-time factor: 1.6633757888038008`

I guess there are few punctuation in Chinese training data, so the pretrained model did not learn the meaning of spaces well. But it learned the meaning of English comma very well through English training data.

BTW, the model learned the meaning of spaces better when I fine-tuned it with my Chinese data with more punctuation.