### PR TITLE
build: pin Trainer to 0.0.34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pandas>=1.4,<2.0
 # deps for training
 matplotlib>=3.7.0
 # coqui stack
-trainer>=0.0.32
+trainer==0.0.34
 # config management
 coqpit>=0.0.16
 # chinese g2p deps


### PR DESCRIPTION
As described in https://github.com/coqui-ai/Trainer/pull/133#issuecomment-1845366504, this temporarily pins the Trainer version to allow making a breaking change there without causing CI failures here. After this, the next steps would be:
- Revert https://github.com/coqui-ai/Trainer/pull/133 and release Trainer 0.0.35: https://github.com/coqui-ai/Trainer/pull/135
- Update TTS so that tests pass and pin Trainer>=0.0.35: #3390