### PR TITLE
support multiple GPU training for XTTS

### DIFF
--- a/TTS/tts/layers/xtts/trainer/gpt_trainer.py
+++ b/TTS/tts/layers/xtts/trainer/gpt_trainer.py
@@ -321,7 +321,10 @@ class GPTTrainer(BaseTTS):
     def on_train_epoch_start(self, trainer):
         trainer.model.eval()  # the whole model to eval
         # put gpt model in training mode
-        trainer.model.xtts.gpt.train()
+        if hasattr(trainer.model, "module") and hasattr(trainer.model.module, "xtts"):
+            trainer.model.module.xtts.gpt.train()
+        else:
+            trainer.model.xtts.gpt.train()
 
     def on_init_end(self, trainer):  # pylint: disable=W0613
         # ignore similarities.pth on clearml save/upload
@@ -387,7 +390,8 @@ class GPTTrainer(BaseTTS):
             else:
                 loader = DataLoader(
                     dataset,
-                    batch_sampler=sampler,
+                    sampler=sampler,
+                    batch_size = config.eval_batch_size if is_eval else config.batch_size,
                     collate_fn=dataset.collate_fn,
                     num_workers=config.num_eval_loader_workers if is_eval else config.num_loader_workers,
                     pin_memory=False,


### PR DESCRIPTION
Set the parameter in `recipes/ljspeech/xtts_v2/train_gpt_xtts.py`
```python
OPTIMIZER_WD_ONLY_ON_WEIGHTS = False  # for multi-gpu training please make it False
```

Now we can run a multi-gpu training using DDP back-end like this:
```bash
$ CUDA_VISIBLE_DEVICES="0, 1" python -m trainer.distribute --script recipes/ljspeech/xtts_v2/train_gpt_xtts.py
```

I ran an experiment with 2 GPUs. Everything seems fine.

I saw a TODO here. But I'm not very familiar with this function. I’m not sure if there will be any problems here compared to single GPU training.
```python
def get_optimizer(self) -> List:
    """Initiate and return the optimizer based on the config parameters."""
    # ToDo: deal with multi GPU training
    if self.config.optimizer_wd_only_on_weights:
```