### PR TITLE
Fix CI (save best model after 0 steps in tests)

### DIFF
--- a/TTS/bin/train_encoder.py
+++ b/TTS/bin/train_encoder.py
@@ -125,7 +125,7 @@ def evaluation(model, criterion, data_loader, global_step):
 
 def train(model, optimizer, scheduler, criterion, data_loader, eval_data_loader, global_step):
     model.train()
-    best_loss = float("inf")
+    best_loss = {"train_loss": None, "eval_loss": float("inf")}
     avg_loader_time = 0
     end_time = time.time()
     for epoch in range(c.epochs):

--- a/TTS/bin/train_encoder.py
+++ b/TTS/bin/train_encoder.py
@@ -248,7 +248,7 @@ def train(model, optimizer, scheduler, criterion, data_loader, eval_data_loader,
             )
             # save the best checkpoint
             best_loss = save_best_model(
-                eval_loss,
+                {"train_loss": None, "eval_loss": eval_loss},
                 best_loss,
                 c,
                 model,

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pandas>=1.4,<2.0
 # deps for training
 matplotlib>=3.7.0
 # coqui stack
-trainer>=0.0.32
+trainer>=0.0.36
 # config management
 coqpit>=0.0.16
 # chinese g2p deps


### PR DESCRIPTION
Only saving the best model after N steps was enabled in https://github.com/coqui-ai/Trainer/commit/c77173d056dfc29baffe0ffd3fee9a9402e6579c. N defaults to 10000, breaking TTS tests: https://github.com/coqui-ai/Trainer/blob/bc68b2a17faf30e88a74f22a5731154f491f5765/trainer/trainer.py#L138

Here I set that value to 0 for the tests.

Also changed TTS/bin/train_encoder.py to use a dictionary for the loss to be consistent with the changes in Trainer 0.0.35