### PR TITLE
Try to Support the XTTS-v2 in Multilingul Cases

### DIFF
--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -113,15 +113,16 @@ synthesizer = Synthesizer(
     use_cuda=args.use_cuda,
 )
 
+speaker_manager = getattr(synthesizer.tts_model, "speaker_manager", None)
 use_multi_speaker = hasattr(synthesizer.tts_model, "num_speakers") and (
     synthesizer.tts_model.num_speakers > 1 or synthesizer.tts_speakers_file is not None
-)
-speaker_manager = getattr(synthesizer.tts_model, "speaker_manager", None)
+) or (speaker_manager is not None)
 
+language_manager = getattr(synthesizer.tts_model, "language_manager", None)
 use_multi_language = hasattr(synthesizer.tts_model, "num_languages") and (
     synthesizer.tts_model.num_languages > 1 or synthesizer.tts_languages_file is not None
-)
-language_manager = getattr(synthesizer.tts_model, "language_manager", None)
+) or (language_manager is not None)
+
 
 # TODO: set this from SpeakerManager
 use_gst = synthesizer.tts_config.get("use_gst", False)


### PR DESCRIPTION
Try to support the XTTS-v2 in multilingul cases, because XTTS-v2 models may not has the num_speakers and num_languages variables.

The reproduce way is run the following command
```
python3 TTS/server/server.py \
    --model_name tts_models/multilingual/multi-dataset/xtts_v2 \
    --config_path /root/.local/share/tts/tts_models--multilingual--multi-dataset--xtts_v2/config.json \
    --model_path /root/.local/share/tts/tts_models--multilingual--multi-dataset--xtts_v2 \
    --use_cuda true \
    --show_details true
```