### PR TITLE
fixing torch device error when synthesizer is called with use_cuda=True

### DIFF
--- a/TTS/tts/models/forward_tts.py
+++ b/TTS/tts/models/forward_tts.py
@@ -398,7 +398,7 @@ class ForwardTTS(BaseTTS):
         """
         if hasattr(self, "emb_g"):
             g = g.type(torch.LongTensor)
-            g = self.emb_g(g)  # [B, C, 1]
+            g = self.emb_g(g.to("cuda") if torch.cuda.is_available() else g.to("cpu"))  # [B, C, 1]
         if g is not None:
             g = g.unsqueeze(-1)
         # [B, T, C]


### PR DESCRIPTION
whenever I declare synthesizer with use_cuda = True. there will be an error that different tensors are in different devices. 
After observation it was found  that input tensor was on "cpu" while weight is on the gpu.
Hence I modified the code to transfer the input to gpu.
It works fine with my code.

Hope this helps !