### PR TITLE
fix(api): handle missing attribute in is_multi_lingual

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -99,7 +99,7 @@ class TTS(nn.Module):
             isinstance(self.model_name, str)
             and "xtts" in self.model_name
             or self.config
-            and ("xtts" in self.config.model or len(self.config.languages) > 1)
+            and ("xtts" in self.config.model or "languages" in self.config and len(self.config.languages) > 1)
         ):
             return True
         if hasattr(self.synthesizer.tts_model, "language_manager") and self.synthesizer.tts_model.language_manager:
@@ -168,9 +168,7 @@ class TTS(nn.Module):
         self.synthesizer = None
         self.model_name = model_name
 
-        model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(
-            model_name
-        )
+        model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(model_name)
 
         # init synthesizer
         # None values are fetch from the model


### PR DESCRIPTION
Fixes #3449, i.e. the following works again:
```python
from TTS.api import TTS

cloud = TTS(model_name="tts_models/de/thorsten/vits")  # just to download the model
_ = cloud.tts("test")  # this works fine

from TTS.utils.generic_utils import get_user_data_dir
model = os.path.join(get_user_data_dir("tts"), "tts_models--de--thorsten--vits", "model_file.pth")
config = os.path.join(get_user_data_dir("tts"), "tts_models--de--thorsten--vits", "config.json")
local = TTS(model_path=model, config_path=config)
_ = local.tts("test")  # this failed previously
```