### PR TITLE
For fairseq fix missing dataset, model var initialization

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -262,6 +262,8 @@ class ModelManager(object):
         if "fairseq" in model_name:
             model_type = "tts_models"
             lang = model_name.split("/")[1]
+            dataset = "fairseq"
+            model = "vits"
             model_item = {
                 "model_type": "tts_models",
                 "license": "CC BY-NC 4.0",


### PR DESCRIPTION
A simple fix for fairseq issue.

Issue : When loading the model we get

```
Traceback (most recent call last):
  File "/home/shoaib/temp.py", line 6, in <module>
    api = TTS("tts_models/pol/fairseq/vits")
  File "/home/shoaib/.local/lib/python3.10/site-packages/TTS/api.py", line 74, in __init__
    self.load_tts_model_by_name(model_name, gpu)
  File "/home/shoaib/.local/lib/python3.10/site-packages/TTS/api.py", line 171, in load_tts_model_by_name
    model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(
  File "/home/shoaib/.local/lib/python3.10/site-packages/TTS/api.py", line 129, in download_model_by_name
    model_path, config_path, model_item = self.manager.download_model(model_name)
  File "/home/shoaib/.local/lib/python3.10/site-packages/TTS/utils/manage.py", line 385, in download_model
    model_item, model_full_name, model, md5sum = self._set_model_item(model_name)
  File "/home/shoaib/.local/lib/python3.10/site-packages/TTS/utils/manage.py", line 304, in _set_model_item
    model_full_name = f"{model_type}--{lang}--{dataset}--{model}"
UnboundLocalError: local variable 'dataset' referenced before assignment
```
Both `dataset` and `model` are not defined/set in the branch that handles `fairseq`.

Addition : Initialized the variables in the branch.

Maybe its better to conform with the rest of the code, where the variables are unpacked from the str.split. What do you think?

PS - could not do a successful `make install` and subsequent test, but successfully tested on applying the changes and testing with this code

```
import torch
from TTS.api import TTS

# Get device
device = "cuda" if torch.cuda.is_available() else "cpu"
api = TTS("tts_models/pol/fairseq/vits")
api.tts_with_vc_to_file(
    "Dzień dobry",
    speaker_wav="speech.wav",
    file_path="output.wav"
)
```