### PR TITLE
Support of the XTTS 2 in tts-server

### DIFF
--- a/TTS/server/server.py
+++ b/TTS/server/server.py
@@ -113,15 +113,15 @@ synthesizer = Synthesizer(
     use_cuda=args.use_cuda,
 )
 
-use_multi_speaker = hasattr(synthesizer.tts_model, "num_speakers") and (
-    synthesizer.tts_model.num_speakers > 1 or synthesizer.tts_speakers_file is not None
-)
 speaker_manager = getattr(synthesizer.tts_model, "speaker_manager", None)
+use_multi_speaker = (hasattr(synthesizer.tts_model, "num_speakers") and (
+    synthesizer.tts_model.num_speakers > 1 or synthesizer.tts_speakers_file is not None
+)) or (speaker_manager is not None)
 
-use_multi_language = hasattr(synthesizer.tts_model, "num_languages") and (
-    synthesizer.tts_model.num_languages > 1 or synthesizer.tts_languages_file is not None
-)
 language_manager = getattr(synthesizer.tts_model, "language_manager", None)
+use_multi_language = (hasattr(synthesizer.tts_model, "num_languages") and (
+    synthesizer.tts_model.num_languages > 1 or synthesizer.tts_languages_file is not None
+)) or (language_manager is not None)
 
 # TODO: set this from SpeakerManager
 use_gst = synthesizer.tts_config.get("use_gst", False)

--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -731,8 +731,8 @@ class Xtts(BaseTTS):
     def load_checkpoint(
         self,
         config,
-        checkpoint_dir=None,
         checkpoint_path=None,
+        checkpoint_dir=None,
         vocab_path=None,
         eval=True,
         strict=True,
@@ -744,8 +744,8 @@ class Xtts(BaseTTS):
 
         Args:
             config (dict): The configuration dictionary for the model.
-            checkpoint_dir (str, optional): The directory where the checkpoint is stored. Defaults to None.
             checkpoint_path (str, optional): The path to the checkpoint file. Defaults to None.
+            checkpoint_dir (str, optional): The directory where the checkpoint is stored. Defaults to None.
             vocab_path (str, optional): The path to the vocabulary file. Defaults to None.
             eval (bool, optional): Whether to set the model to evaluation mode. Defaults to True.
             strict (bool, optional): Whether to strictly enforce that the keys in the checkpoint match the keys in the model. Defaults to True.
@@ -753,7 +753,8 @@ class Xtts(BaseTTS):
         Returns:
             None
         """
-
+        if checkpoint_dir is None and checkpoint_path:
+            checkpoint_dir = os.path.dirname(checkpoint_path)
         model_path = checkpoint_path or os.path.join(checkpoint_dir, "model.pth")
         vocab_path = vocab_path or os.path.join(checkpoint_dir, "vocab.json")
 

--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -414,7 +414,7 @@ class ModelManager(object):
         output_model_path = output_path
         output_config_path = None
         if (
-            model not in ["tortoise-v2", "bark"] and "fairseq" not in model_name and "xtts" not in model_name
+            model not in ["tortoise-v2", "bark"] and "fairseq" not in model_name and "xtts1" not in model_name
         ):  # TODO:This is stupid but don't care for now.
             output_model_path, output_config_path = self._find_files(output_path)
         # update paths in the config.json


### PR DESCRIPTION
Related issues: #3454 #3271 #3140 

---

### Description
This Pull Request changes behaviour of `Xtts#load_checkpoint`, and `ModelManager#download_model`.
Changes:
  - Excluded xtts 2 from configuration ignore list in `ModelManager` for proper `config_path` resolution in `tts-server`
  - Swapped `checkpoint_path`, `checkpoint_dir` parameters to follow the `BaseTrainerModel` implementation

Fixes:
```python
Traceback (most recent call last):
  File "/root/TTS/server/server.py", line 104, in <module>
    synthesizer = Synthesizer(
  File "/root/TTS/utils/synthesizer.py", line 93, in __init__
    self._load_tts(tts_checkpoint, tts_config_path, use_cuda)
  File "/root/TTS/utils/synthesizer.py", line 183, in _load_tts
    self.tts_config = load_config(tts_config_path)
  File "/root/TTS/config/__init__.py", line 82, in load_config
    ext = os.path.splitext(config_path)[1]
  File "/usr/lib/python3.10/posixpath.py", line 118, in splitext
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
  
---

### Current state
This Pull Request is tested with xtts2 model, and without specifying xtts2 model, it works fine.
Have a nice day! 