### PR TITLE
Remove redundant calls to keys() method of name_to_id

### DIFF
--- a/TTS/tts/layers/xtts/xtts_manager.py
+++ b/TTS/tts/layers/xtts/xtts_manager.py
@@ -14,7 +14,7 @@ class SpeakerManager():
     
     @property
     def speaker_names(self):
-        return list(self.name_to_id.keys())
+        return list(self.name_to_id)
     
 
 class LanguageManager():


### PR DESCRIPTION
Fix the problem that I mentioned in https://github.com/coqui-ai/TTS/issues/3434#issuecomment-1871181181.

`name_to_id()` in class `SpeakerManager` already returns `dict_keys` type, but `keys()` method is called again on `name_to_id` in `speaker_names()`, which results in the error `AttributeError: 'dict_keys' object has no attribute 'keys'`