### PR TITLE
fix: fairseq model

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -260,10 +260,13 @@ class ModelManager(object):
     def _set_model_item(self, model_name):
         # fetch model info from the dict
         if "fairseq" in model_name:
-            model_type = "tts_models"
-            lang = model_name.split("/")[1]
+            split = model_name.split("/")
+            model_type = split[0]
+            lang = split[1]
+            dataset = split[2]
+            model = split[3]
             model_item = {
-                "model_type": "tts_models",
+                "model_type": model_type,
                 "license": "CC BY-NC 4.0",
                 "default_vocoder": None,
                 "author": "fairseq",


### PR DESCRIPTION
Fix error when using `fairseq` model. The `dataset` and `model` aren't being defined and throw an error:

Sample:

```python
from TTS.api import TTS

# TTS with on the fly voice conversion
api = TTS("tts_models/eng/fairseq/vits").to("cpu")
api.tts_with_vc_to_file(
    "Things that are fixed with great speed, but as a result, it's probably not going to work very well.",
    speaker_wav="target/speaker.wav",
    file_path="output.wav"
)
```

error:

```sh
Traceback (most recent call last):
  File "/var/www/python/coquitts-poc/./fairseq.py", line 13, in <module>
    tts = TTS(model_name="tts_models/eng/fairseq/vits").to("cpu")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/python/coquitts-poc/TTS/TTS/api.py", line 74, in __init__
    self.load_tts_model_by_name(model_name, gpu)
  File "/var/www/python/coquitts-poc/TTS/TTS/api.py", line 171, in load_tts_model_by_name
    model_path, config_path, vocoder_path, vocoder_config_path, model_dir = self.download_model_by_name(
                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/python/coquitts-poc/TTS/TTS/api.py", line 129, in download_model_by_name
    model_path, config_path, model_item = self.manager.download_model(model_name)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/python/coquitts-poc/TTS/TTS/utils/manage.py", line 388, in download_model
    model_item, model_full_name, model, md5sum = self._set_model_item(model_name)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/www/python/coquitts-poc/TTS/TTS/utils/manage.py", line 307, in _set_model_item
    model_full_name = f"{model_type}--{lang}--{dataset}--{model}"
                                               ^^^^^^^
UnboundLocalError: cannot access local variable 'dataset' where it is not associated with a value
```

fixes: #3142 #3361