### PR TITLE
Fix grammar for split_sentences print message

### DIFF
--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -294,7 +294,7 @@ class Synthesizer(nn.Module):
         if text:
             sens = [text]
             if split_sentences:
-                print(" > Text splitted to sentences.")
+                print(" > Text split into sentences.")
                 sens = self.split_into_sentences(text)
             print(sens)
 


### PR DESCRIPTION
Update the printed message when split_sentences is used.