### PR TITLE
Fix for dataset and model variables Errors when downloading fairseq m…

### DIFF
--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -260,8 +260,9 @@ class ModelManager(object):
     def _set_model_item(self, model_name):
         # fetch model info from the dict
         if "fairseq" in model_name:
+            model_attributes = model_name.split("/")
             model_type = "tts_models"
-            lang = model_name.split("/")[1]
+            lang = model_attributes[1]
             model_item = {
                 "model_type": "tts_models",
                 "license": "CC BY-NC 4.0",
@@ -270,6 +271,9 @@ class ModelManager(object):
                 "description": "this model is released by Meta under Fairseq repo. Visit https://github.com/facebookresearch/fairseq/tree/main/examples/mms for more info.",
             }
             model_item["model_name"] = model_name
+            dataset = model_attributes[2]
+            model = model_attributes[3]
+            
         elif "xtts" in model_name and len(model_name.split("/")) != 4:
             # loading xtts models with only model name (e.g. xtts_v2.0.2)
             # check model name has the version number with regex


### PR DESCRIPTION
…odels

in the original implementation, the dataset and model variables were causing errors due to uninitialized in the TTS fairseq models.

Changes Made:

Introduced a line to split model_name into model_attributes based on the '/' delimiter. This ensures that the different components of the model name (language, dataset, model) can be separately and accurately accessed. Added lines to explicitly extract lang, dataset, and model from model_attributes using their respective indices. This change makes the code more robust and clear, as it directly links the variables to their sources: lang is now set to the second component (model_attributes[1]), dataset to the third (model_attributes[2]),
model to the fourth (model_attributes[3]).