### PR TITLE
Fix issues for fairseq model handling and VC when speaker_wav is passed

### DIFF
--- a/TTS/api.py
+++ b/TTS/api.py
@@ -413,7 +413,7 @@ class TTS(nn.Module):
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as fp:
             # Lazy code... save it to a temp file to resample it while reading it for VC
             self.tts_to_file(
-                text=text, speaker=speaker, language=language, file_path=fp.name, split_sentences=split_sentences
+                text=text, speaker=speaker, speaker_wav=speaker_wav, language=language, file_path=fp.name, split_sentences=split_sentences
             )
         if self.voice_converter is None:
             self.load_vc_model_by_name("voice_conversion_models/multilingual/vctk/freevc24")

--- a/TTS/utils/manage.py
+++ b/TTS/utils/manage.py
@@ -262,6 +262,8 @@ class ModelManager(object):
         if "fairseq" in model_name:
             model_type = "tts_models"
             lang = model_name.split("/")[1]
+            dataset = model_name.split("/")[2]
+            model = model_name.split("/")[3]
             model_item = {
                 "model_type": "tts_models",
                 "license": "CC BY-NC 4.0",


### PR DESCRIPTION
When we use the model "tts_models/eng/fairseq/vits", got the following error.

Error in text to speech: cannot access local variable 'dataset' where it is not associated with a value

at line ..../.conda/envs/venv/lib/python3.11/site-packages/TTS/utils/manage.py", line 304, in _set_model_item
    model_full_name = f"{model_type}--{lang}--{dataset}--{model}"