### PR TITLE
Fix a typo in the TTS python package

### DIFF
--- a/TTS/utils/synthesizer.py
+++ b/TTS/utils/synthesizer.py
@@ -294,7 +294,7 @@ class Synthesizer(nn.Module):
         if text:
             sens = [text]
             if split_sentences:
-                print(" > Text splitted to sentences.")
+                print(" > Text split into sentences.")
                 sens = self.split_into_sentences(text)
             print(sens)
 


### PR DESCRIPTION
Changed "Text splitted to sentences" to "Text split into sentences".

This is a small change, but I hope it helps. I love this project and want to contribute however I can! :)