### PR TITLE
XTTS Fix: conditioning length float error fix

### DIFF
--- a/TTS/tts/models/xtts.py
+++ b/TTS/tts/models/xtts.py
@@ -271,8 +271,8 @@ class Xtts(BaseTTS):
             audio = audio[:, : 22050 * length]
         if self.args.gpt_use_perceiver_resampler:
             style_embs = []
-            for i in range(0, audio.shape[1], 22050 * chunk_length):
-                audio_chunk = audio[:, i : i + 22050 * chunk_length]
+            for i in range(0, audio.shape[1], int(22050 * chunk_length)):
+                audio_chunk = audio[:, i : i + int(22050 * chunk_length)]
 
                 # if the chunk is too short ignore it 
                 if audio_chunk.size(-1) < 22050 * 0.33:


### PR DESCRIPTION
When generating the speaker reference latent and supplying a floating point conditioning length, `get_gpt_cond_latents` throws an error, as when it calculates the samples it needs, it does not cast to an int.

```py
for i in range(0, audio.shape[1], 22050 * chunk_length):
```
->
```py
for i in range(0, audio.shape[1], int(22050 * chunk_length)):
```