### PR TITLE
Fix: Add weights_only=False for PyTorch 2.6+ compatibility

### DIFF
--- a/TTS/utils/io.py
+++ b/TTS/utils/io.py
@@ -48,10 +48,10 @@ def load_fsspec(
             filecache={"cache_storage": str(get_user_data_dir("tts_cache"))},
             mode="rb",
         ) as f:
-            return torch.load(f, map_location=map_location, **kwargs)
+            return torch.load(f, map_location=map_location, **kwargs, weights_only=False)
     else:
         with fsspec.open(path, "rb") as f:
-            return torch.load(f, map_location=map_location, **kwargs)
+            return torch.load(f, map_location=map_location, **kwargs, weights_only=False)
 
 
 def load_checkpoint(


### PR DESCRIPTION
PyTorch 2.6 Compatibility Improvement

Problem

In PyTorch 2.6, the default value for `weights_only` in `torch.load` has changed from False to True.
This causes a type error when loading TTS models.

Solution

Explicitly set `weights_only=False` in the `load_fsspec` function within `io.py` when calling torch.load.
