### PR TITLE
Hebrew diacritics normalization + support direct phoneme input via [[...]] blocks

### DIFF
--- a/TTS/tts/utils/text/cleaners.py
+++ b/TTS/tts/utils/text/cleaners.py
@@ -11,6 +11,7 @@ from .english.abbreviations import abbreviations_en
 from .english.number_norm import normalize_numbers as en_normalize_numbers
 from .english.time_norm import expand_time_english
 from .french.abbreviations import abbreviations_fr
+from .hebrew.diacritics import normalize_hebrew_diacritics
 
 # Regular expression matching whitespace:
 _whitespace_re = re.compile(r"\s+")
@@ -164,6 +165,12 @@ def multilingual_cleaners(text):
     text = collapse_whitespace(text)
     return text
 
+def hebrew_cleaners(text):
+    text = lowercase(text)
+    text = replace_symbols(text, lang=None)
+    text = collapse_whitespace(text)
+    text = normalize_hebrew_diacritics(text)
+    return text
 
 def no_cleaners(text):
     # remove newline characters

--- a/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
+++ b/TTS/tts/utils/text/phonemizers/espeak_wrapper.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import subprocess
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from packaging.version import Version
 
@@ -80,6 +80,22 @@ def _espeak_exe(espeak_lib: str, args: List, sync=False) -> List[str]:
     return res2
 
 
+def _restore_text_in_double_brackets(text, bracket_matches):
+    # if there are no double brackets, return the text as is
+    if not bracket_matches:
+        return text
+
+    def restore_brackets(match):
+        nonlocal bracket_matches
+        return f"[[{bracket_matches.pop(0)}]]" if bracket_matches else match.group()
+
+    new_text = text.copy()
+    for i in range(len(text)):
+        new_text[i] = re.sub('\uE000', restore_brackets, text[i])
+
+    return new_text
+
+
 class ESpeak(BasePhonemizer):
     """ESpeak wrapper calling `espeak` or `espeak-ng` from the command-line the perform G2P
 
@@ -109,10 +125,11 @@ class ESpeak(BasePhonemizer):
     _ESPEAK_LIB = _DEF_ESPEAK_LIB
     _ESPEAK_VER = _DEF_ESPEAK_VER
 
-    def __init__(self, language: str, backend=None, punctuations=Punctuation.default_puncs(), keep_puncs=True):
+    def __init__(self, language: str, backend=None, punctuations=Punctuation.default_puncs(), keep_puncs=True, accept_phonemes_directly=False):
         if self._ESPEAK_LIB is None:
             raise Exception(" [!] No espeak backend found. Install espeak-ng or espeak to your system.")
         self.backend = self._ESPEAK_LIB
+        self.accept_phonemes_directly = accept_phonemes_directly
 
         # band-aid for backwards compatibility
         if language == "en":
@@ -208,6 +225,24 @@ class ESpeak(BasePhonemizer):
     def _phonemize(self, text, separator=None):
         return self.phonemize_espeak(text, separator, tie=False)
 
+    def _phonemize_preprocess(self, text) -> Tuple[List[str], List]:
+        """Preprocess the text before phonemization
+
+        In case we want to preserve direct phonemes we switch the phonemes inside double brackets to empty
+        double brackets and then apply the super method
+        """
+
+        bracket_matches = []
+        if self.accept_phonemes_directly:
+            bracket_matches = re.findall(r'\[\[(.*?)\]\]', text)
+            text = re.sub(r'\[\[.*?\]\]', '\uE000', text)
+
+        # Apply the super method to handle punctuation and spaces
+        text, punctuations = super()._phonemize_preprocess(text)
+
+        # Split the text by spaces to phonemize each part separately
+        return _restore_text_in_double_brackets(text, bracket_matches), punctuations
+
     @staticmethod
     def supported_languages() -> Dict:
         """Get a dictionary of supported languages.
@@ -248,6 +283,14 @@ class ESpeak(BasePhonemizer):
         """Return true if ESpeak is available else false"""
         return is_tool("espeak") or is_tool("espeak-ng")
 
+    # set to accept phonemes directly
+    def set_accept_phonemes_directly(self, accept: bool = True):
+        """Set to accept phonemes directly in double brackets.
+
+        Args:
+            accept (bool): If True, accept phonemes directly in double brackets.
+        """
+        self.accept_phonemes_directly = accept
 
 if __name__ == "__main__":
     e = ESpeak(language="en-us")

--- a/tests/text_tests/test_phonemizer.py
+++ b/tests/text_tests/test_phonemizer.py
@@ -116,6 +116,13 @@ class TestEspeakNgPhonemizer(unittest.TestCase):
         output = self.phonemizer.phonemize(text, separator="")
         self.assertEqual(output, gt)
 
+        # insert phonemes directly
+        self.phonemizer.set_accept_phonemes_directly()
+        text = "Be a voice, [[n'0t an]] echo?"
+        gt = "biːʲ ɐ vˈɔɪs, nˈɑːt æn ˈɛkoʊ?"
+        output = self.phonemizer.phonemize(text, separator="")
+        self.assertEqual(output, gt)
+
     def test_name(self):
         self.assertEqual(self.phonemizer.name(), "espeak")
 

--- a/tests/text_tests/test_text_cleaners.py
+++ b/tests/text_tests/test_text_cleaners.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from TTS.tts.utils.text.cleaners import english_cleaners, phoneme_cleaners
+from TTS.tts.utils.text.cleaners import english_cleaners, phoneme_cleaners, hebrew_cleaners
 
 
 def test_time() -> None:
@@ -19,3 +19,7 @@ def test_currency() -> None:
 def test_expand_numbers() -> None:
     assert phoneme_cleaners("-1") == "minus one"
     assert phoneme_cleaners("1") == "one"
+
+def test_hebrew_cleaners() -> None:
+    assert hebrew_cleaners("שָׁלוֹם") == "שָׁלוֹם"
+    assert hebrew_cleaners("שִׁשִּׁי") == "שִׁשִּׁי"


### PR DESCRIPTION
**1. Add Hebrew diacritics normalization and corresponding tests**

- Introduced normalize_hebrew_diacritics() in hebrew/diacritics.py to correct niqqud and dagesh/sin-dot ordering.
- Added hebrew_cleaners() to text cleaners registry to apply this normalization.
- Registered the function in cleaners.py with lowercase, symbol replacement, and whitespace collapse.
- Added unit tests in test_text_cleaners.py to validate expected Hebrew normalization behavior.

This ensures that diacritics appear in a consistent canonical order: (dagesh > shin/sin dots > vowel marks)
improving rendering reliability and text comparison accuracy in Hebrew TTS pipelines.


**2. espeak phonemizer: support direct phoneme input via [[...]] blocks** 

- Added `accept_phonemes_directly` option to the ESpeak phonemizer.
- When enabled, text enclosed in [[...]] is treated as raw phonemes and excluded from G2P.
- This feature is supported natively by the eSpeak library.
- Implemented `_phonemize_preprocess` override to strip and later restore [[...]] content.
- Added `set_accept_phonemes_directly()` setter for runtime control.
- Included unit test to verify inline phoneme passthrough behavior.