### PR TITLE
Fix invalid JSON: Replace float('inf') with valid values and add validation

### DIFF
--- a/TTS/tts/configs/shared_configs.py
+++ b/TTS/tts/configs/shared_configs.py
@@ -51,20 +51,27 @@ class GSTConfig(Coqpit):
 @dataclass
 class CapacitronVAEConfig(Coqpit):
     """Defines the capacitron VAE Module
+
     Args:
         capacitron_capacity (int):
             Defines the variational capacity limit of the prosody embeddings. Defaults to 150.
+
         capacitron_VAE_embedding_dim (int):
             Defines the size of the Capacitron embedding vector dimension. Defaults to 128.
+
         capacitron_use_text_summary_embeddings (bool):
             If True, use a text summary embedding in Capacitron. Defaults to True.
+
         capacitron_text_summary_embedding_dim (int):
             Defines the size of the capacitron text embedding vector dimension. Defaults to 128.
+
         capacitron_use_speaker_embedding (bool):
             if True use speaker embeddings in Capacitron. Defaults to False.
+
         capacitron_VAE_loss_alpha (float):
             Weight for the VAE loss of the Tacotron model. If set less than or equal to zero, it disables the
             corresponding loss function. Defaults to 0.25
+
         capacitron_grad_clip (float):
             Gradient clipping value for all gradients except beta. Defaults to 5.0
     """
@@ -136,10 +143,8 @@ class CharactersConfig(Coqpit):
     """
 
     characters_class: str = None
-
     # using BaseVocabulary
     vocab_dict: Dict = None
-
     # using on BaseCharacters
     pad: str = None
     eos: str = None
@@ -157,7 +162,6 @@ class BaseTTSConfig(BaseTrainingConfig):
     """Shared parameters among all the tts models.
 
     Args:
-
         audio (BaseAudioConfig):
             Audio processor config object instance.
 
@@ -204,7 +208,7 @@ class BaseTTSConfig(BaseTrainingConfig):
             Minimum length of input text to be used. All shorter samples will be ignored. Defaults to 0.
 
         max_text_len (int):
-            Maximum length of input text to be used. All longer samples will be ignored. Defaults to float("inf").
+            Maximum length of input text to be used. All longer samples will be ignored. Defaults to 999999999.
 
         min_audio_len (int):
             Minimum length of input audio to be used. All shorter samples will be ignored. Defaults to 0.
@@ -212,7 +216,7 @@ class BaseTTSConfig(BaseTrainingConfig):
         max_audio_len (int):
             Maximum length of input audio to be used. All longer samples will be ignored. The maximum length in the
             dataset defines the VRAM used in the training. Hence, pay attention to this value if you encounter an
-            OOM error in training. Defaults to float("inf").
+            OOM error in training. Defaults to 999999999.
 
         compute_f0 (int):
             (Not in use yet).
@@ -311,9 +315,9 @@ class BaseTTSConfig(BaseTrainingConfig):
     loss_masking: bool = None
     # dataloading
     min_audio_len: int = 1
-    max_audio_len: int = float("inf")
+    max_audio_len: int = 999999999
     min_text_len: int = 1
-    max_text_len: int = float("inf")
+    max_text_len: int = 999999999
     compute_f0: bool = False
     compute_energy: bool = False
     compute_linear_spec: bool = False

--- a/scripts/validate_json_configs.py
+++ b/scripts/validate_json_configs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate JSON configuration files for invalid values.
+
+This script checks JSON files to ensure they don't contain
+invalid values like Infinity or NaN that are not compliant
+with the JSON standard.
+
+Usage:
+    python scripts/validate_json_configs.py [path]
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def validate_json_file(filepath):
+    """Validate a single JSON file for invalid values.
+    
+    Args:
+        filepath: Path to the JSON file to validate
+        
+    Returns:
+        tuple: (is_valid, error_message)
+    """
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+            
+        # Check for invalid JSON values
+        invalid_patterns = ['Infinity', 'NaN', '-Infinity']
+        found_issues = []
+        
+        for pattern in invalid_patterns:
+            if pattern in content:
+                found_issues.append(pattern)
+                
+        if found_issues:
+            return False, f"Found invalid JSON values: {', '.join(found_issues)}"
+        
+        # Try to parse the JSON to ensure it's valid
+        try:
+            json.loads(content)
+        except json.JSONDecodeError as e:
+            return False, f"JSON parse error: {e}"
+            
+        return True, None
+        
+    except Exception as e:
+        return False, f"Error reading file: {e}"
+
+
+def main():
+    """Main function to validate JSON config files."""
+    # Default to checking common config locations
+    search_paths = [
+        Path('TTS/tts/configs'),
+        Path('TTS/vocoder/configs'),
+        Path('TTS/encoder/configs'),
+    ]
+    
+    # Allow custom path from command line
+    if len(sys.argv) > 1:
+        search_paths = [Path(sys.argv[1])]
+    
+    all_valid = True
+    files_checked = 0
+    
+    for search_path in search_paths:
+        if not search_path.exists():
+            continue
+            
+        # Find all .json files
+        json_files = list(search_path.rglob('*.json'))
+        
+        for json_file in json_files:
+            files_checked += 1
+            is_valid, error_msg = validate_json_file(json_file)
+            
+            if not is_valid:
+                print(f"❌ INVALID: {json_file}")
+                print(f"   {error_msg}")
+                all_valid = False
+            else:
+                print(f"✓ VALID: {json_file}")
+    
+    print(f"\nChecked {files_checked} JSON file(s)")
+    
+    if all_valid:
+        print("✓ All JSON files are valid!")
+        return 0
+    else:
+        print("❌ Some JSON files contain invalid values!")
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Fixes #4341

## Problem

Python's `json.dump()` can write `Infinity` values to JSON files, but these are not valid according to the JSON standard. When config files are saved with `float("inf")` values for `max_audio_len` and `max_text_len`, they fail JSON validation in tools like jsonlint.

## Changes

### 1. Fixed invalid JSON values in config defaults
- Replaced `max_audio_len: int = float("inf")` → `max_audio_len: int = 999999999`
- Replaced `max_text_len: int = float("inf")` → `max_text_len: int = 999999999`
- Updated docstrings to reflect the new default values
- File: `TTS/tts/configs/shared_configs.py`

### 2. Added JSON validation script
- Created `scripts/validate_json_configs.py` to check for invalid JSON values
- Detects `Infinity`, `NaN`, and `-Infinity` in JSON files
- Can be used manually or integrated into CI workflows
- Validates JSON files in common config directories

## Validation Approach

The validation script can be used in multiple ways:
1. **Manual validation**: `python scripts/validate_json_configs.py`
2. **CI integration**: Add to GitHub Actions or other CI systems
3. **Pre-commit hook**: Validate before committing changes

This ensures that invalid JSON values are caught early and prevents similar issues in the future.

## Testing

The script has been tested locally and can validate existing config files. To use:
```bash
python scripts/validate_json_configs.py
```

These changes maintain backward compatibility while ensuring all generated config files conform to the JSON standard.