### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -191,4 +191,4 @@ api.tts_with_vc_to_file(
 )
 ```
 
-**Note:** The same OpenAI Python client pattern also works with any OpenAI-compatible multi-model gateway when you are not running TTS locally — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.
+**Note:** The same OpenAI Python client pattern also works with any OpenAI-compatible multi-model gateway when you are not running TTS locally — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.

--- a/docs/source/inference.md
+++ b/docs/source/inference.md
@@ -190,3 +190,5 @@ api.tts_with_vc_to_file(
     file_path="ouptut.wav"
 )
 ```
+
+**Note:** The same OpenAI Python client pattern also works with any OpenAI-compatible multi-model gateway when you are not running TTS locally — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.


### PR DESCRIPTION
## What
Added a brief note about using OpenAI-compatible multi-model gateways (example: DaoXE) with the OpenAI Python client.

## Why
Help users who want to use multi-model gateways without self-hosting TTS.

## How
- Inserted a short note in the inference / docs with UTM-tracked link for analytics.
- No code changes, docs only.

### Changes
- Docs: added DaoXE multi-model gateway note with UTM.

### Checklist
- [x] Docs only
- [x] No breaking changes
- [x] Link includes UTM parameters